### PR TITLE
feat: add release version to User-Agent request header

### DIFF
--- a/internal/provider/check_rule_resource_acc_test.go
+++ b/internal/provider/check_rule_resource_acc_test.go
@@ -280,6 +280,7 @@ func testAccCheckCheckRuleExists(resourceName string) resource.TestCheckFunc {
 		c := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
+			"test",
 		)
 
 		// Attempt to retrieve the check rule

--- a/internal/provider/client/check_rule_test.go
+++ b/internal/provider/client/check_rule_test.go
@@ -158,7 +158,7 @@ spec:
 			defer server.Close()
 
 			// Create client
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 			ctx := context.Background()
 			var err error
 
@@ -247,7 +247,7 @@ func TestCheckRuleOperations_IntegrationStyle(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewDash0Client(server.URL, "test-token")
+	client := NewDash0Client(server.URL, "test-token", "test")
 
 	// Test check rule data
 	testOrigin := "test-check-rule"
@@ -381,7 +381,7 @@ spec:
 
 func TestCheckRuleClient_InvalidYAML(t *testing.T) {
 	ctx := context.Background()
-	client := NewDash0Client("http://localhost", "test-token")
+	client := NewDash0Client("http://localhost", "test-token", "test")
 
 	checkRuleModel := model.CheckRule{
 		Origin:        types.StringValue("test-origin"),
@@ -461,7 +461,7 @@ spec:
 			}))
 			defer server.Close()
 
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 
 			err := client.CreateCheckRule(ctx, tc.model)
 			if tc.wantErr {
@@ -475,7 +475,7 @@ spec:
 
 func TestCheckRuleClient_UnsupportedYAMLFormats(t *testing.T) {
 	ctx := context.Background()
-	client := NewDash0Client("http://localhost", "test-token")
+	client := NewDash0Client("http://localhost", "test-token", "test")
 
 	tests := []struct {
 		name string
@@ -587,7 +587,7 @@ func TestCheckRuleClient_FloatThresholds(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 			checkRule, err := client.GetCheckRule(context.Background(), "default", "test-origin")
 
 			require.NoError(t, err)

--- a/internal/provider/client/client_test.go
+++ b/internal/provider/client/client_test.go
@@ -56,7 +56,7 @@ func TestDoRequest(t *testing.T) {
 				// Verify request headers
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				assert.Equal(t, "application/json", r.Header.Get("Accept"))
-				assert.Equal(t, "Dash0 Terraform Provider", r.Header.Get("User-Agent"))
+				assert.Equal(t, "Dash0 Terraform Provider/test", r.Header.Get("User-Agent"))
 				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 
 				// Verify request path
@@ -71,7 +71,7 @@ func TestDoRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			c := NewDash0Client(server.URL, "test-token")
+			c := NewDash0Client(server.URL, "test-token", "test")
 
 			// Make request
 			resp, err := c.doRequest(context.Background(), tc.method, tc.path, tc.body)

--- a/internal/provider/client/dashboard_test.go
+++ b/internal/provider/client/dashboard_test.go
@@ -131,7 +131,7 @@ func TestDashboardOperations(t *testing.T) {
 			defer server.Close()
 
 			// Create client
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 			ctx := context.Background()
 			var err error
 
@@ -218,7 +218,7 @@ func TestDashboardOperations_IntegrationStyle(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewDash0Client(server.URL, "test-token")
+	client := NewDash0Client(server.URL, "test-token", "test")
 
 	// Test dashboard data
 	testOrigin := "test-dashboard"

--- a/internal/provider/client/synthetic_check_test.go
+++ b/internal/provider/client/synthetic_check_test.go
@@ -134,7 +134,7 @@ spec:
 			defer server.Close()
 
 			// Create client
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 
 			// Execute operation
 			var err error
@@ -168,7 +168,7 @@ spec:
 
 func TestSyntheticCheckClient_InvalidYAML(t *testing.T) {
 	ctx := context.Background()
-	client := NewDash0Client("http://localhost", "test-token")
+	client := NewDash0Client("http://localhost", "test-token", "test")
 
 	checkModel := model.SyntheticCheck{
 		Origin:             types.StringValue("test-origin"),

--- a/internal/provider/client/view_test.go
+++ b/internal/provider/client/view_test.go
@@ -135,7 +135,7 @@ spec:
 			defer server.Close()
 
 			// Create client
-			client := NewDash0Client(server.URL, "test-token")
+			client := NewDash0Client(server.URL, "test-token", "test")
 			ctx := context.Background()
 			var err error
 
@@ -222,7 +222,7 @@ func TestViewOperations_IntegrationStyle(t *testing.T) {
 	defer server.Close()
 
 	// Create client
-	client := NewDash0Client(server.URL, "test-token")
+	client := NewDash0Client(server.URL, "test-token", "test")
 
 	// Test view data
 	testOrigin := "test-view"
@@ -329,7 +329,7 @@ func TestViewOperations_IntegrationStyle(t *testing.T) {
 
 func TestViewClient_InvalidYAML(t *testing.T) {
 	ctx := context.Background()
-	client := NewDash0Client("http://localhost", "test-token")
+	client := NewDash0Client("http://localhost", "test-token", "test")
 
 	viewModel := model.ViewResource{
 		Origin:   types.StringValue("test-origin"),

--- a/internal/provider/dashboard_resource_acc_test.go
+++ b/internal/provider/dashboard_resource_acc_test.go
@@ -175,6 +175,7 @@ func testAccCheckDashboardExists(resourceName string) resource.TestCheckFunc {
 		c := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
+			"test",
 		)
 
 		// Attempt to retrieve the dashboard

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,7 +113,7 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 	tflog.Debug(ctx, "Creating Dash0 client")
 
 	// Create dash0Client configuration for data sources and resources
-	dash0Client := client.NewDash0Client(url, authToken)
+	dash0Client := client.NewDash0Client(url, authToken, p.version)
 
 	resp.DataSourceData = dash0Client
 	resp.ResourceData = dash0Client

--- a/internal/provider/synthetic_check_resource_acc_test.go
+++ b/internal/provider/synthetic_check_resource_acc_test.go
@@ -234,6 +234,7 @@ func testAccCheckSyntheticCheckExists(resourceName string) resource.TestCheckFun
 		client := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
+			"test",
 		)
 
 		// Attempt to retrieve the synthetic check

--- a/internal/provider/view_resource_acc_test.go
+++ b/internal/provider/view_resource_acc_test.go
@@ -275,6 +275,7 @@ func testAccCheckViewExists(resourceName string) resource.TestCheckFunc {
 		client := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
+			"test",
 		)
 
 		// Attempt to retrieve the view


### PR DESCRIPTION
In order to facilitate debugging issues with the Terraform provider, the HTTP client now sends the release version of the Terraform provider as part of the `User-Agent` HTTP request header.