### PR TITLE
fix: make YAML semantic comparison resilient to round-trip formatting differences

### DIFF
--- a/internal/converter/normalizer.go
+++ b/internal/converter/normalizer.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -54,16 +55,36 @@ func NormalizeYAML(yamlStr string) (string, error) {
 	return string(result), nil
 }
 
-// removeZeroThresholdAnnotations removes dash0-threshold-critical and dash0-threshold-degraded
-// annotations when their value is "0". This treats zero-value thresholds as semantically
-// equivalent to not having the annotation, ensuring consistent comparison regardless of
-// whether the user includes them in their config.
-func removeZeroThresholdAnnotations(annotations map[string]interface{}) {
+// stringifyMapValues converts all non-string values in a map to their string
+// representation. This is used for annotation maps which are semantically
+// map[string]string, but untyped YAML parsing may produce non-string types
+// (e.g., an unquoted 5000 becomes int, true becomes bool).
+func stringifyMapValues(m map[string]interface{}) {
+	for key, value := range m {
+		if _, ok := value.(string); !ok {
+			m[key] = fmt.Sprintf("%v", value)
+		}
+	}
+}
+
+// removeDefaultAnnotationValues removes annotations whose values match the defaults
+// used by the check rule round-trip conversion. This ensures that explicitly setting
+// a default value is treated as semantically equivalent to omitting the annotation.
+//   - dash0-threshold-critical: "0" and dash0-threshold-degraded: "0" are removed
+//     because zero-value thresholds are omitted during the Dash0 JSON → Prometheus YAML conversion.
+//   - dash0-enabled: "true" is removed because true is the default and is omitted
+//     during the Dash0 JSON → Prometheus YAML conversion (see check_rule.go).
+func removeDefaultAnnotationValues(annotations map[string]interface{}) {
 	for key, value := range annotations {
-		if key == "dash0-threshold-critical" || key == "dash0-threshold-degraded" {
-			if strVal, ok := value.(string); ok && strVal == "0" {
-				delete(annotations, key)
-			}
+		strVal, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if (key == "dash0-threshold-critical" || key == "dash0-threshold-degraded") && strVal == "0" {
+			delete(annotations, key)
+		}
+		if key == "dash0-enabled" && strVal == "true" {
+			delete(annotations, key)
 		}
 	}
 }
@@ -93,9 +114,17 @@ func cleanupMap(data map[string]interface{}, fieldsToRemove []string) {
 		switch v := value.(type) {
 		case map[string]interface{}:
 			cleanupMap(v, nestedRemovals[key])
-			// Remove zero-value threshold annotations for semantic equivalence
+			if key == "annotations" || key == "labels" {
+				// Annotations and labels are semantically map[string]string, but untyped
+				// YAML parsing may produce non-string types (e.g., unquoted 5000 becomes
+				// int, unquoted true becomes bool). Stringify all values so comparison
+				// matches the round-tripped form.
+				stringifyMapValues(v)
+			}
 			if key == "annotations" {
-				removeZeroThresholdAnnotations(v)
+				// Remove annotations with default values for semantic equivalence.
+				// IMPORTANT: Must be called after stringifyMapValues since it expects string values.
+				removeDefaultAnnotationValues(v)
 			}
 			if isEmpty(v) {
 				delete(data, key)
@@ -112,6 +141,14 @@ func cleanupMap(data map[string]interface{}, fieldsToRemove []string) {
 		case string:
 			if v == "" {
 				delete(data, key)
+			} else if key == "keep_firing_for" {
+				// keep_firing_for uses Duration with omitempty, so yaml.Marshal drops
+				// it when the value is zero. Remove it here so "keep_firing_for: 0s"
+				// in user YAML matches the round-tripped YAML that omits the field.
+				// If parsing fails, the value is not a duration, so keep it as-is.
+				if d, err := time.ParseDuration(v); err == nil && d == 0 {
+					delete(data, key)
+				}
 			}
 		}
 	}
@@ -143,6 +180,34 @@ func isEmpty(m map[string]interface{}) bool {
 	return true
 }
 
+// normalizeNumericTypes recursively converts all integer and float types to float64
+// in a parsed YAML/JSON structure. This ensures consistent comparison when the same
+// numeric value appears as different types (e.g., int in YAML and float64 in JSON).
+func normalizeNumericTypes(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, v := range val {
+			val[k] = normalizeNumericTypes(v)
+		}
+		return val
+	case []interface{}:
+		for i, v := range val {
+			val[i] = normalizeNumericTypes(v)
+		}
+		return val
+	case int:
+		return float64(val)
+	case int32:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case float32:
+		return float64(val)
+	default:
+		return v
+	}
+}
+
 // ResourceYAMLEquivalent checks if two resource YAMLs are equivalent,
 // ignoring fields we don't care about for drift detection
 func ResourceYAMLEquivalent(yamlA, yamlB string) (bool, error) {
@@ -166,10 +231,30 @@ func ResourceYAMLEquivalent(yamlA, yamlB string) (bool, error) {
 		return false, fmt.Errorf("error parsing second normalized resource yaml: %w", err)
 	}
 
-	// make sure that the order of slices deeper in the structure does not matter
-	cmpOptions := []cmp.Option{cmpopts.SortSlices(func(x, y interface{}) bool {
-		return fmt.Sprint(x) < fmt.Sprint(y)
-	})}
+	// Normalize numeric types (int -> float64) to handle YAML vs JSON type differences
+	parsedA = normalizeNumericTypes(parsedA)
+	parsedB = normalizeNumericTypes(parsedB)
+
+	cmpOptions := []cmp.Option{
+		// Ignore order of slices deeper in the structure
+		cmpopts.SortSlices(func(x, y interface{}) bool {
+			return fmt.Sprint(x) < fmt.Sprint(y)
+		}),
+		// Duration-aware string comparison: treats "2m" and "2m0s" as equivalent
+		// when both strings are valid Go duration strings
+		cmp.FilterValues(
+			func(x, y string) bool {
+				_, errX := time.ParseDuration(x)
+				_, errY := time.ParseDuration(y)
+				return errX == nil && errY == nil
+			},
+			cmp.Comparer(func(x, y string) bool {
+				dx, _ := time.ParseDuration(x)
+				dy, _ := time.ParseDuration(y)
+				return dx == dy
+			}),
+		),
+	}
 	// Compare the parsed structures
 	return cmp.Equal(parsedA, parsedB, cmpOptions...), nil
 }

--- a/internal/provider/check_rule_resource_acc_test.go
+++ b/internal/provider/check_rule_resource_acc_test.go
@@ -14,6 +14,12 @@ import (
 
 const checkRuleResourceName = "dash0_check_rule.test"
 
+// basicCheckRuleYaml uses various YAML formatting styles to test round-trip resilience:
+//   - Short-form durations (1m, 5m) that may be normalized to 1m0s, 5m0s
+//   - Unquoted numeric annotation (5000) that may be stringified to "5000"
+//   - Quoted numeric annotation ("1000") for comparison
+//
+// These formatting differences should not cause state drift.
 const basicCheckRuleYaml = `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -21,14 +27,16 @@ metadata:
 spec:
   groups:
     - name: TestAlerts
-      interval: 1m0s
+      interval: 1m
       rules:
         - alert: TestServiceDown
           expr: up{job="test-service"} == 0
-          for: 5m0s
+          for: 5m
           annotations:
             summary: 'Test service is down'
             description: 'Test service has been down for more than 5 minutes'
+            dash0-threshold-critical: 5000
+            dash0-threshold-degraded: "1000"
           labels:
             severity: critical`
 

--- a/internal/provider/planmodifier/yaml_semantic_equal_test.go
+++ b/internal/provider/planmodifier/yaml_semantic_equal_test.go
@@ -112,6 +112,40 @@ spec:
 			description:  "Should use config value when YAML parsing fails",
 		},
 		{
+			name: "different duration formats - should use state (2m vs 2m0s)",
+			configValue: types.StringValue(`
+spec:
+  groups:
+    - interval: 2m
+      name: test-group
+      rules:
+        - alert: test-alert
+          for: 5m
+          expr: test > 0
+`),
+			stateValue: types.StringValue(`
+spec:
+  groups:
+    - interval: 2m0s
+      name: test-group
+      rules:
+        - alert: test-alert
+          for: 5m0s
+          expr: test > 0
+`),
+			expectedPlan: types.StringValue(`
+spec:
+  groups:
+    - interval: 2m0s
+      name: test-group
+      rules:
+        - alert: test-alert
+          for: 5m0s
+          expr: test > 0
+`),
+			description: "Should use state value when duration formats differ but represent same duration",
+		},
+		{
 			name: "complex nested structure with ordering differences - should use state",
 			configValue: types.StringValue(`
 spec:


### PR DESCRIPTION
The check rule round-trip (user YAML → Dash0 JSON → Prometheus YAML) introduces formatting changes that caused spurious state drift on every plan/apply:
- Duration normalization: "2m" becomes "2m0s"
- Unquoted YAML values: 5000 (int) becomes "5000" (string) in annotations/labels
- Default annotation removal: dash0-enabled "true" is dropped (true is the default)
- Zero-duration omitempty: keep_firing_for "0s" is dropped by yaml.Marshal

The normalizer now handles all these cases so ResourceYAMLEquivalent treats them as semantically equivalent, preventing unnecessary Terraform state updates.