### PR TITLE
build(go): skip deprecated GOOS=windows GOARCH=arm build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm
     dir: ./
     main: ./main.go
     binary: '{{ .ProjectName }}_v{{ .Version }}'


### PR DESCRIPTION
see: https://go.dev/doc/go1.26#windows