### PR TITLE
fix(SUP-678): conditionally ignore spec.permissions and null values in YAML normalization

### DIFF
--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -148,7 +148,9 @@ func (r *CheckRuleResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// Compare the current state with the retrieved check rule
 	// Only update state if there's a significant change (ignoring certain fields)
 	if state.CheckRuleYaml.ValueString() != "" {
-		equivalent, err := converter.ResourceYAMLEquivalent(state.CheckRuleYaml.ValueString(), check.CheckRuleYaml.ValueString())
+		stateYAML := state.CheckRuleYaml.ValueString()
+		additionalIgnored := converter.FieldsAbsentFromYAML(stateYAML, converter.ConditionallyIgnoredFields)
+		equivalent, err := converter.ResourceYAMLEquivalent(stateYAML, check.CheckRuleYaml.ValueString(), additionalIgnored...)
 		if err != nil {
 			resp.Diagnostics.AddWarning(
 				"Check Rule Comparison Error",

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -145,7 +145,9 @@ func (r *DashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// Compare the current state with the retrieved dashboard
 	// Only update state if there's a significant change (ignoring certain fields)
 	if state.DashboardYaml.ValueString() != "" {
-		equivalent, err := converter.ResourceYAMLEquivalent(state.DashboardYaml.ValueString(), dashboard.DashboardYaml.ValueString())
+		stateYAML := state.DashboardYaml.ValueString()
+		additionalIgnored := converter.FieldsAbsentFromYAML(stateYAML, converter.ConditionallyIgnoredFields)
+		equivalent, err := converter.ResourceYAMLEquivalent(stateYAML, dashboard.DashboardYaml.ValueString(), additionalIgnored...)
 		if err != nil {
 			resp.Diagnostics.AddWarning(
 				"Dashboard Comparison Error",

--- a/internal/provider/planmodifier/yaml_semantic_equal_test.go
+++ b/internal/provider/planmodifier/yaml_semantic_equal_test.go
@@ -146,6 +146,97 @@ spec:
 			description: "Should use state value when duration formats differ but represent same duration",
 		},
 		{
+			name: "config without permissions, state with permissions - should use state",
+			configValue: types.StringValue(`
+spec:
+  enabled: true
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			stateValue: types.StringValue(`
+spec:
+  enabled: true
+  permissions:
+    - actions:
+        - "synthetic_check:read"
+        - "synthetic_check:delete"
+      role: admin
+    - actions:
+        - "synthetic_check:read"
+      role: basic_member
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			expectedPlan: types.StringValue(`
+spec:
+  enabled: true
+  permissions:
+    - actions:
+        - "synthetic_check:read"
+        - "synthetic_check:delete"
+      role: admin
+    - actions:
+        - "synthetic_check:read"
+      role: basic_member
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			description: "Should use state value when config omits permissions (API-added field conditionally ignored)",
+		},
+		{
+			name: "config with permissions, state with different permissions - should use config",
+			configValue: types.StringValue(`
+spec:
+  enabled: true
+  permissions:
+    - actions:
+        - "synthetic_check:read"
+      role: admin
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			stateValue: types.StringValue(`
+spec:
+  enabled: true
+  permissions:
+    - actions:
+        - "synthetic_check:read"
+        - "synthetic_check:delete"
+      role: admin
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			expectedPlan: types.StringValue(`
+spec:
+  enabled: true
+  permissions:
+    - actions:
+        - "synthetic_check:read"
+      role: admin
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://test.example.com
+`),
+			description: "Should use config value when config includes permissions and they differ (drift detected)",
+		},
+		{
 			name: "complex nested structure with ordering differences - should use state",
 			configValue: types.StringValue(`
 spec:

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -145,7 +145,9 @@ func (r *SyntheticCheckResource) Read(ctx context.Context, req resource.ReadRequ
 	// Compare the current state with the retrieved synthetic check
 	// Only update state if there's a significant change (ignoring certain fields)
 	if state.SyntheticCheckYaml.ValueString() != "" {
-		equivalent, err := converter.ResourceYAMLEquivalent(state.SyntheticCheckYaml.ValueString(), check.SyntheticCheckYaml.ValueString())
+		stateYAML := state.SyntheticCheckYaml.ValueString()
+		additionalIgnored := converter.FieldsAbsentFromYAML(stateYAML, converter.ConditionallyIgnoredFields)
+		equivalent, err := converter.ResourceYAMLEquivalent(stateYAML, check.SyntheticCheckYaml.ValueString(), additionalIgnored...)
 		if err != nil {
 			resp.Diagnostics.AddWarning(
 				"Synthetic Check Comparison Error",

--- a/internal/provider/synthetic_check_resource_read_test.go
+++ b/internal/provider/synthetic_check_resource_read_test.go
@@ -69,6 +69,10 @@ spec:
         url: https://different.example.com
 `
 
+	// API response with permissions added by the API (JSON format, matching real API behavior).
+	// The API stores permissions in a separate table and enriches the response on retrieval.
+	apiResponseWithPermissions := `{"kind":"Dash0SyntheticCheck","metadata":{"annotations":{},"labels":{"dash0.com/dataset":"test-dataset","dash0.com/id":"test-uuid","dash0.com/origin":"tf_test-origin","dash0.com/version":"1"},"name":"test-check"},"spec":{"enabled":true,"permissions":[{"actions":["synthetic_check:read","synthetic_check:delete"],"role":"admin"},{"actions":["synthetic_check:read"],"role":"basic_member"}],"plugin":{"kind":"http","spec":{"request":{"url":"https://test.example.com"}}}}}`
+
 	tests := []struct {
 		name              string
 		currentState      string
@@ -80,6 +84,13 @@ spec:
 			name:              "metadata changes only - no significant diff",
 			currentState:      baseYAML,
 			apiResponse:       yamlWithMetadataChanges,
+			expectStateUpdate: false,
+			expectWarning:     false,
+		},
+		{
+			name:              "API adds permissions - no significant diff",
+			currentState:      baseYAML,
+			apiResponse:       apiResponseWithPermissions,
 			expectStateUpdate: false,
 			expectWarning:     false,
 		},

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -145,7 +145,9 @@ func (r *ViewResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	// Compare the current state with the retrieved view
 	// Only update state if there's a significant change (ignoring certain fields)
 	if state.ViewYaml.ValueString() != "" {
-		equivalent, err := converter.ResourceYAMLEquivalent(state.ViewYaml.ValueString(), check.ViewYaml.ValueString())
+		stateYAML := state.ViewYaml.ValueString()
+		additionalIgnored := converter.FieldsAbsentFromYAML(stateYAML, converter.ConditionallyIgnoredFields)
+		equivalent, err := converter.ResourceYAMLEquivalent(stateYAML, check.ViewYaml.ValueString(), additionalIgnored...)
 		if err != nil {
 			resp.Diagnostics.AddWarning(
 				"View Comparison Error",


### PR DESCRIPTION
- Fix phantom diffs on dash0_synthetic_check caused by API-enriched spec.permissions and JSON null values
- Permissions are conditionally ignored: if omitted from config, no diff; if included, drift detection is preserved
-  Handle JSON null values (e.g., "channels": null) that caused false differences after unmarshalling