### PR TITLE
test: use correct region for synthetic check acc tests

### DIFF
--- a/internal/provider/synthetic_check_resource_acc_test.go
+++ b/internal/provider/synthetic_check_resource_acc_test.go
@@ -72,7 +72,7 @@ spec:
   schedule:
     interval: 5m
     locations:
-      - gcp-us-west1
+      - us-oregon
     strategy: all_locations`
 
 const updatedSyntheticCheckYaml = `
@@ -133,7 +133,7 @@ spec:
   schedule:
     interval: 5m
     locations:
-      - gcp-us-west1
+      - us-oregon
     strategy: all_locations`
 
 func TestAccSyntheticCheckResource(t *testing.T) {
@@ -261,7 +261,7 @@ spec:
   schedule:
     interval: 5m
     locations:
-      - gcp-us-west1
+      - us-oregon
     strategy: all_locations`
 
 // TestAccSyntheticCheckResource_WithoutPermissions verifies that configs without


### PR DESCRIPTION
tests are failing with this message
```
Unable to create synthetic check, got error: API error (400):
{"error":{"code":400,"message":"Bad Request: The submitted synthetic check
contains invalid location(s): gcp-us-west1. Valid locations are:
de-frankfurt, us-oregon.","traceId":"d462793c35d67e45ec1fd66a94b8372d"}}
```