### PR TITLE
Add OpenTofu registry manifest and include it in release archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,8 @@ archives:
   - formats: [ 'zip' ]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - terraform-registry-manifest.json
 
 release:
   prerelease: "false"

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}


### PR DESCRIPTION
Add terraform-registry-manifest.json declaring protocol version 6.0 (terraform-plugin-framework) and update .goreleaser.yaml to bundle the manifest in release zip archives, as required by the OpenTofu registry provider protocol.