### PR TITLE
fix(ci): use goinstall mode for golangci-lint to support Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.9
+          install-mode: goinstall
 
       - name: Build & Test
         run: |


### PR DESCRIPTION
The golangci-lint pre-built binaries (install-mode: binary) are compiled
with Go 1.25, which refuses to lint projects targeting Go 1.26. Using
install-mode: goinstall builds golangci-lint from source with the
project's Go 1.26 toolchain, resolving the version mismatch.

https://claude.ai/code/session_011xnoA7rTABhBV8pXs4NB6k