### PR TITLE
chore(deps): update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dash0hq/terraform-provider-dash0
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
- Update Go version from 1.26 to 1.26.2 in `go.mod`
- CI workflows already use `go-version-file` so they pick up the change automatically
