### PR TITLE
fix: stabilize flaky view roundtrip test

### DIFF
--- a/.chloggen/fix-flaky-view-roundtrip-test.yaml
+++ b/.chloggen/fix-flaky-view-roundtrip-test.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: views
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix flaky view roundtrip test caused by unstable YAML comparison and eventual consistency
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [75]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Replace fmt.Sprint-based sort keys in ResourceYAMLEquivalent with a canonical string function
+  that recursively sorts nested structures, ensuring stable order-independent YAML comparison.
+  Add retry-based helpers (assert_idempotent, assert_yaml_equivalent_eventually) to tolerate
+  eventual consistency of server-managed fields like permissions. Extract the duplicated
+  idempotency check pattern into the shared assert_idempotent helper.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/internal/converter/normalizer.go
+++ b/internal/converter/normalizer.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -207,6 +208,35 @@ func isEmpty(m map[string]interface{}) bool {
 	return true
 }
 
+// canonicalString produces a deterministic string representation of a value,
+// recursively sorting maps by key and slices by their canonical representation.
+// This ensures that the SortSlices comparator produces stable sort keys even
+// when nested structures (like action lists within permissions) differ in order.
+func canonicalString(v interface{}) string {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, k+":"+canonicalString(val[k]))
+		}
+		return "{" + strings.Join(parts, ",") + "}"
+	case []interface{}:
+		strs := make([]string, len(val))
+		for i, item := range val {
+			strs[i] = canonicalString(item)
+		}
+		sort.Strings(strs)
+		return "[" + strings.Join(strs, ",") + "]"
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
 // normalizeNumericTypes recursively converts all integer and float types to float64
 // in a parsed YAML/JSON structure. This ensures consistent comparison when the same
 // numeric value appears as different types (e.g., int in YAML and float64 in JSON).
@@ -277,9 +307,12 @@ func ResourceYAMLEquivalent(yamlA, yamlB string, additionalIgnoredFields ...stri
 	}
 
 	cmpOptions := []cmp.Option{
-		// Ignore order of slices deeper in the structure
+		// Ignore order of slices deeper in the structure.
+		// Uses canonicalString which recursively sorts nested structures so that
+		// the sort key is stable regardless of inner element ordering (e.g., if
+		// the API returns list items in a different order than the user's config).
 		cmpopts.SortSlices(func(x, y interface{}) bool {
-			return fmt.Sprint(x) < fmt.Sprint(y)
+			return canonicalString(x) < canonicalString(y)
 		}),
 		// Duration-aware string comparison: treats "2m" and "2m0s" as equivalent
 		// when both strings are valid Go duration strings

--- a/internal/converter/normalizer_test.go
+++ b/internal/converter/normalizer_test.go
@@ -1126,6 +1126,94 @@ func TestRemoveYAMLField(t *testing.T) {
 	}
 }
 
+func TestCanonicalString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "string value",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "int value",
+			input:    42,
+			expected: "42",
+		},
+		{
+			name:     "bool value",
+			input:    true,
+			expected: "true",
+		},
+		{
+			name:     "map with sorted keys",
+			input:    map[string]interface{}{"b": "2", "a": "1"},
+			expected: "{a:1,b:2}",
+		},
+		{
+			name:     "slice elements are sorted",
+			input:    []interface{}{"cherry", "apple", "banana"},
+			expected: "[apple,banana,cherry]",
+		},
+		{
+			name: "nested map with unsorted inner list produces same canonical form regardless of list order",
+			input: map[string]interface{}{
+				"role":    "admin",
+				"actions": []interface{}{"views:read", "views:delete"},
+			},
+			expected: "{actions:[views:delete,views:read],role:admin}",
+		},
+		{
+			name: "same nested map with different inner list order produces identical canonical form",
+			input: map[string]interface{}{
+				"role":    "admin",
+				"actions": []interface{}{"views:delete", "views:read"},
+			},
+			expected: "{actions:[views:delete,views:read],role:admin}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canonicalString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResourceYAMLEquivalent_PermissionsWithReorderedActions(t *testing.T) {
+	// This test verifies that permissions with actions in different order are
+	// treated as equivalent, and that the outer permissions sort is stable even
+	// when inner action lists differ in order.
+	yaml1 := `
+spec:
+  permissions:
+    - actions:
+        - "views:read"
+        - "views:delete"
+      role: admin
+    - actions:
+        - "views:read"
+      role: basic_member
+`
+	yaml2 := `
+spec:
+  permissions:
+    - actions:
+        - "views:read"
+      role: basic_member
+    - actions:
+        - "views:delete"
+        - "views:read"
+      role: admin
+`
+	result, err := ResourceYAMLEquivalent(yaml1, yaml2)
+	require.NoError(t, err)
+	assert.True(t, result, "permissions with reordered actions and reordered entries should be equivalent")
+}
+
 func TestNormalizeNumericTypes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/roundtrip/common.sh
+++ b/test/roundtrip/common.sh
@@ -254,6 +254,85 @@ assert_deleted_via_tf() {
 }
 
 # ---------------------------------------------------------------------------
+# Idempotency check with retry (handles eventual consistency).
+# ---------------------------------------------------------------------------
+
+# assert_idempotent <work_dir> [max_retries] [delay]
+#
+# Runs `tofu plan -detailed-exitcode` and expects exit code 0 (no changes).
+# Retries up to max_retries times (default 5) with delay seconds (default 3)
+# between attempts to tolerate eventual consistency of server-managed fields
+# like permissions that are stored separately and enriched on retrieval.
+assert_idempotent() {
+  local dir="$1"
+  local max_retries="${2:-5}"
+  local delay="${3:-3}"
+
+  for i in $(seq 1 "$max_retries"); do
+    set +e
+    TF_VAR_dataset="$DATASET" tf_plan_detailed_exitcode "$dir"
+    local exit_code=$?
+    set -e
+
+    if [[ "$exit_code" -eq 0 ]]; then
+      info "Idempotency check PASSED: no changes detected (attempt ${i})."
+      return 0
+    elif [[ "$exit_code" -eq 2 ]]; then
+      if [[ "$i" -lt "$max_retries" ]]; then
+        warn "Idempotency check detected changes (attempt ${i}/${max_retries}), retrying in ${delay}s..."
+        sleep "$delay"
+      else
+        fail "Idempotency check FAILED: Terraform detected changes on a no-op re-apply (after ${max_retries} attempts)."
+      fi
+    else
+      fail "Idempotency check ERROR: tofu plan exited with code ${exit_code}."
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# YAML equivalence check with retry (handles eventual consistency).
+# ---------------------------------------------------------------------------
+
+# assert_yaml_equivalent_eventually <uploaded_file> <cli_command> <id> <dataset> [max_retries] [delay]
+#
+# Fetches the resource via CLI and checks YAML equivalence against the uploaded
+# file. Retries on failure to tolerate eventual consistency (e.g., permissions
+# not yet enriched in the API response).
+assert_yaml_equivalent_eventually() {
+  local uploaded_file="$1"
+  local cli_cmd="$2"
+  local id="$3"
+  local dataset="$4"
+  local max_retries="${5:-5}"
+  local delay="${6:-3}"
+
+  for i in $(seq 1 "$max_retries"); do
+    local cli_output
+    cli_output="$($cli_cmd get "$id" --dataset "$dataset" -o yaml 2>&1)" \
+      || fail "CLI could not find resource ${id}"
+
+    set +e
+    assert_yaml_equivalent "$uploaded_file" "$cli_output"
+    local rc=$?
+    set -e
+
+    if [[ "$rc" -eq 0 ]]; then
+      info "YAML equivalence check PASSED (attempt ${i})."
+      return 0
+    fi
+
+    if [[ "$i" -lt "$max_retries" ]]; then
+      warn "YAML equivalence check failed (attempt ${i}/${max_retries}), retrying in ${delay}s..."
+      sleep "$delay"
+    else
+      echo "$cli_output"
+      fail "Uploaded and downloaded YAMLs are not equivalent (after ${max_retries} attempts)."
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Cleanup helper — removes a temp directory on EXIT.
 # Usage: at the top of each test:  WORK_DIR=$(mktemp -d) ; trap "rm -rf $WORK_DIR" EXIT
 # ---------------------------------------------------------------------------

--- a/test/roundtrip/test_check_rule.sh
+++ b/test/roundtrip/test_check_rule.sh
@@ -137,19 +137,7 @@ info "Update verified via CLI."
 # Step 4: Idempotency — re-apply without changes
 # ---------------------------------------------------------------------------
 info "Step 4: Re-applying without changes (idempotency test)..."
-
-set +e
-TF_VAR_dataset="$DATASET" tf_plan_detailed_exitcode "$WORK_DIR"
-EXIT_CODE=$?
-set -e
-
-if [[ "$EXIT_CODE" -eq 0 ]]; then
-  info "Idempotency check PASSED: no changes detected."
-elif [[ "$EXIT_CODE" -eq 2 ]]; then
-  fail "Idempotency check FAILED: Terraform detected changes on a no-op re-apply."
-else
-  fail "Idempotency check ERROR: tofu plan exited with code ${EXIT_CODE}."
-fi
+assert_idempotent "$WORK_DIR"
 
 # ---------------------------------------------------------------------------
 # Step 5: Destroy

--- a/test/roundtrip/test_dashboard.sh
+++ b/test/roundtrip/test_dashboard.sh
@@ -161,19 +161,7 @@ info "Update verified via CLI."
 # Step 4: Idempotency
 # ---------------------------------------------------------------------------
 info "Step 4: Re-applying without changes (idempotency test)..."
-
-set +e
-TF_VAR_dataset="$DATASET" tf_plan_detailed_exitcode "$WORK_DIR"
-EXIT_CODE=$?
-set -e
-
-if [[ "$EXIT_CODE" -eq 0 ]]; then
-  info "Idempotency check PASSED: no changes detected."
-elif [[ "$EXIT_CODE" -eq 2 ]]; then
-  fail "Idempotency check FAILED: Terraform detected changes on a no-op re-apply."
-else
-  fail "Idempotency check ERROR: tofu plan exited with code ${EXIT_CODE}."
-fi
+assert_idempotent "$WORK_DIR"
 
 # ---------------------------------------------------------------------------
 # Step 5: Destroy

--- a/test/roundtrip/test_synthetic_check.sh
+++ b/test/roundtrip/test_synthetic_check.sh
@@ -163,19 +163,7 @@ info "Update verified via CLI."
 # Step 4: Idempotency
 # ---------------------------------------------------------------------------
 info "Step 4: Re-applying without changes (idempotency test)..."
-
-set +e
-TF_VAR_dataset="$DATASET" tf_plan_detailed_exitcode "$WORK_DIR"
-EXIT_CODE=$?
-set -e
-
-if [[ "$EXIT_CODE" -eq 0 ]]; then
-  info "Idempotency check PASSED: no changes detected."
-elif [[ "$EXIT_CODE" -eq 2 ]]; then
-  fail "Idempotency check FAILED: Terraform detected changes on a no-op re-apply."
-else
-  fail "Idempotency check ERROR: tofu plan exited with code ${EXIT_CODE}."
-fi
+assert_idempotent "$WORK_DIR"
 
 # ---------------------------------------------------------------------------
 # Step 5: Destroy

--- a/test/roundtrip/test_view.sh
+++ b/test/roundtrip/test_view.sh
@@ -94,9 +94,9 @@ echo "$CLI_OUTPUT" | grep -qi "roundtrip-test-view\|Roundtrip Test View" \
   || fail "CLI output does not contain expected view name"
 
 info "Step 2b: Checking YAML equivalence (uploaded vs downloaded)..."
-assert_yaml_equivalent "${WORK_DIR}/view.yaml" "$CLI_OUTPUT" \
-  || fail "Uploaded and downloaded view YAMLs are not equivalent"
-info "View equivalence check PASSED."
+# Uses retry to tolerate eventual consistency of server-managed fields like
+# permissions, which are stored separately and enriched on retrieval.
+assert_yaml_equivalent_eventually "${WORK_DIR}/view.yaml" "dash0 views" "$ORIGIN" "$DATASET"
 
 # ---------------------------------------------------------------------------
 # Step 3: Update
@@ -158,18 +158,9 @@ info "Update verified via CLI."
 # ---------------------------------------------------------------------------
 info "Step 4: Re-applying without changes (idempotency test)..."
 
-set +e
-TF_VAR_dataset="$DATASET" tf_plan_detailed_exitcode "$WORK_DIR"
-EXIT_CODE=$?
-set -e
-
-if [[ "$EXIT_CODE" -eq 0 ]]; then
-  info "Idempotency check PASSED: no changes detected."
-elif [[ "$EXIT_CODE" -eq 2 ]]; then
-  fail "Idempotency check FAILED: Terraform detected changes on a no-op re-apply."
-else
-  fail "Idempotency check ERROR: tofu plan exited with code ${EXIT_CODE}."
-fi
+# Uses retry to tolerate eventual consistency of server-managed fields like
+# permissions, which are stored separately and enriched on retrieval.
+assert_idempotent "$WORK_DIR"
 
 # ---------------------------------------------------------------------------
 # Step 5: Destroy


### PR DESCRIPTION
Two issues caused the view roundtrip test to fail intermittently:

1. The SortSlices comparator in ResourceYAMLEquivalent used fmt.Sprint for sort keys, which includes nested arrays in their original order. When the API returns actions within permissions in a different order, the Sprint representation changes, causing the outer sort to pair elements incorrectly. Replace with canonicalString that recursively sorts all nested structures before producing the sort key.

2. The view test includes spec.permissions which are stored separately and enriched on retrieval (eventual consistency). Add retry-based helpers (assert_idempotent, assert_yaml_equivalent_eventually) to tolerate brief propagation delays for server-managed fields.

Also extract the duplicated idempotency check pattern from all roundtrip tests into the shared assert_idempotent helper.