### PR TITLE
feat(docs): update AWS CloudFormation example to v2 template

### DIFF
--- a/docs/guides/aws_cloudformation_integration.md
+++ b/docs/guides/aws_cloudformation_integration.md
@@ -11,14 +11,15 @@ This guide shows how to deploy the Dash0 AWS integration using Terraform's [`aws
 
 ~> **Note:** This is not a native Dash0 provider resource. It uses the AWS provider to deploy a CloudFormation stack with the official Dash0 integration template.
 
-The integration provisions the required IAM roles and configuration for collecting telemetry from your AWS account.
+The integration provisions the required IAM roles and configuration for collecting telemetry from your AWS account. The v2 template additionally provisions, via a CloudFormation StackSet, a Kinesis Firehose delivery stream, a CloudWatch metric stream and an S3 backup bucket per region for the `AWS/Lambda` namespace.
 
 ## Prerequisites
 
 - An active [Dash0](https://dash0.com) organization.
 - A Dash0 **API key** (auth token), created under **Settings > Auth Tokens** in the Dash0 UI.
 - Your Dash0 organization **technical ID**, found under **Settings > Organization** in the Dash0 UI.
-- An AWS account with permissions to create CloudFormation stacks and IAM roles.
+- Your Dash0 **CloudWatch Metrics Firehose ingress URL**, found under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics`).
+- An AWS account with permissions to create CloudFormation stacks, StackSets, and IAM roles.
 - Terraform >= 1.0 and the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest) >= 5.0.
 
 ## Example Usage
@@ -30,20 +31,24 @@ The core resource definition is:
 ```terraform
 resource "aws_cloudformation_stack" "dash0_integration" {
   name         = "dash0-integration"
-  template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation.json"
+  template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation-v2.yaml"
 
   parameters = {
     ApiKey                   = var.api_key
     Dataset                  = var.dataset
     ResourcesInstrumentation = var.resources_instrumentation
     TechnicalId              = var.technical_id
+    Regions                  = join(",", var.regions)
+    Dash0IngressUrl          = var.dash0_ingress_url
   }
 
-  capabilities = ["CAPABILITY_NAMED_IAM"]
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }
 ```
 
-The `CAPABILITY_NAMED_IAM` capability is required because the template creates named IAM roles for the Dash0 integration.
+The `CAPABILITY_NAMED_IAM` capability is required because the template creates named IAM roles for the Dash0 integration. The `CAPABILITY_AUTO_EXPAND` capability is required because the v2 template includes a nested `AWS::CloudFormation::StackSet` that deploys the per-region Lambda metrics streaming resources.
+
+CloudFormation expects `Regions` to be a `CommaDelimitedList`, so the Terraform list variable is joined into a comma-separated string before being passed to the stack.
 
 ## CloudFormation Parameters
 
@@ -51,8 +56,10 @@ The `CAPABILITY_NAMED_IAM` capability is required because the template creates n
 |-----------|-------------|----------|---------|
 | `ApiKey` | Dash0 API key (auth token) for the integration. | Yes | -- |
 | `Dataset` | The Dash0 dataset to send telemetry data to. | No | `default` |
-| `ResourcesInstrumentation` | Enable instrumentation of AWS Lambda and other resources (`"true"` or `"false"`). | No | `"false"` |
+| `ResourcesInstrumentation` | Enable instrumentation of AWS Lambda and other resources (`"true"` or `"false"`). | No | `"true"` |
 | `TechnicalId` | The Dash0 organization technical ID. | Yes | -- |
+| `Regions` | Comma-separated list of AWS regions in which to enable `AWS/Lambda` metrics streaming (for example `eu-west-1,us-east-1`). | Yes | -- |
+| `Dash0IngressUrl` | Regional Firehose ingress endpoint for your Dash0 organization. Find it under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics`). | Yes | -- |
 
 ## Getting Started
 
@@ -61,8 +68,10 @@ The `CAPABILITY_NAMED_IAM` capability is required because the template creates n
 2. Create a `terraform.tfvars` file with your values (do **not** commit this file):
 
    ```hcl
-   api_key      = "your-dash0-auth-token"
-   technical_id = "your-organization-technical-id"
+   api_key           = "your-dash0-auth-token"
+   technical_id      = "your-organization-technical-id"
+   dash0_ingress_url = "https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics"
+   regions           = ["eu-west-1"]
    ```
 
 3. Initialize and apply:
@@ -82,4 +91,5 @@ The `CAPABILITY_NAMED_IAM` capability is required because the template creates n
 ## Notes
 
 - The `api_key` variable is marked as `sensitive` so Terraform will not display its value in plan or apply output.
-- The CloudFormation stack is region-specific. Deploy it in the region where your AWS workloads run, or in the region closest to your Dash0 environment.
+- The CloudFormation stack is region-specific. Deploy it in the region where your AWS workloads run, or in the region closest to your Dash0 environment. The `Regions` parameter controls which regions the nested StackSet provisions Lambda metrics streaming into; it is independent from the region the parent stack itself is deployed in.
+- The S3 backup bucket created by the StackSet is retained on `terraform destroy` by design. Delete it manually if you want to fully reclaim the bucket name before re-onboarding.

--- a/docs/guides/aws_cloudformation_integration.md
+++ b/docs/guides/aws_cloudformation_integration.md
@@ -11,16 +11,17 @@ This guide shows how to deploy the Dash0 AWS integration using Terraform's [`aws
 
 ~> **Note:** This is not a native Dash0 provider resource. It uses the AWS provider to deploy a CloudFormation stack with the official Dash0 integration template.
 
-The integration provisions the required IAM roles and configuration for collecting telemetry from your AWS account. The v2 template additionally provisions, via a CloudFormation StackSet, a Kinesis Firehose delivery stream, a CloudWatch metric stream and an S3 backup bucket per region for the `AWS/Lambda` namespace.
+The integration provisions the required IAM roles and configuration for collecting telemetry from your AWS account. The v2 template additionally provisions, via a CloudFormation StackSet, per-region resources for the `AWS/Lambda` namespace — a Kinesis Firehose delivery stream, a CloudWatch metric stream and an S3 backup bucket — and, optionally, an EventBridge rule, ApiDestination, and Connection that forward Lambda lifecycle events (`UpdateFunctionConfiguration`, `DeleteFunction`) to Dash0 in near real-time.
 
 ## Prerequisites
 
 - An active [Dash0](https://dash0.com) organization.
 - A Dash0 **API key** (auth token), created under **Settings > Auth Tokens** in the Dash0 UI.
 - Your Dash0 organization **technical ID**, found under **Settings > Organization** in the Dash0 UI.
-- Your Dash0 **CloudWatch Metrics Firehose ingress URL**, found under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics`).
+- Your Dash0 **regional endpoint base URL**, found under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com`). Provide only the base URL — the template appends the required paths internally.
 - An AWS account with permissions to create CloudFormation stacks, StackSets, and IAM roles.
 - Terraform >= 1.0 and the [AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest) >= 5.0.
+- To collect Lambda lifecycle events (enabled by default), a CloudTrail trail logging management events in each region listed in `Regions`. Most AWS accounts already have an org-wide trail; if yours does not, either enable one or set `CollectLambdaLifecycleEvents` to `"false"`.
 
 ## Example Usage
 
@@ -34,19 +35,20 @@ resource "aws_cloudformation_stack" "dash0_integration" {
   template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation-v2.yaml"
 
   parameters = {
-    ApiKey                   = var.api_key
-    Dataset                  = var.dataset
-    ResourcesInstrumentation = var.resources_instrumentation
-    TechnicalId              = var.technical_id
-    Regions                  = join(",", var.regions)
-    Dash0IngressUrl          = var.dash0_ingress_url
+    ApiKey                       = var.api_key
+    Dataset                      = var.dataset
+    ResourcesInstrumentation     = var.resources_instrumentation
+    CollectLambdaLifecycleEvents = var.collect_lambda_lifecycle_events
+    TechnicalId                  = var.technical_id
+    Regions                      = join(",", var.regions)
+    Dash0RegionalEndpoint        = var.dash0_regional_endpoint
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }
 ```
 
-The `CAPABILITY_NAMED_IAM` capability is required because the template creates named IAM roles for the Dash0 integration. The `CAPABILITY_AUTO_EXPAND` capability is required because the v2 template includes a nested `AWS::CloudFormation::StackSet` that deploys the per-region Lambda metrics streaming resources.
+The `CAPABILITY_NAMED_IAM` capability is required because the template creates named IAM roles for the Dash0 integration. The `CAPABILITY_AUTO_EXPAND` capability is required because the v2 template includes a nested `AWS::CloudFormation::StackSet` that deploys the per-region Dash0 resources (Lambda metrics streaming and, optionally, Lambda lifecycle event forwarding).
 
 CloudFormation expects `Regions` to be a `CommaDelimitedList`, so the Terraform list variable is joined into a comma-separated string before being passed to the stack.
 
@@ -57,9 +59,10 @@ CloudFormation expects `Regions` to be a `CommaDelimitedList`, so the Terraform 
 | `ApiKey` | Dash0 API key (auth token) for the integration. | Yes | -- |
 | `Dataset` | The Dash0 dataset to send telemetry data to. | No | `default` |
 | `ResourcesInstrumentation` | Enable instrumentation of AWS Lambda and other resources (`"true"` or `"false"`). | No | `"true"` |
+| `CollectLambdaLifecycleEvents` | Forward AWS Lambda lifecycle events (`UpdateFunctionConfiguration`, `DeleteFunction`) to Dash0 via EventBridge (`"true"` or `"false"`). Requires a CloudTrail trail logging management events in the selected regions. | No | `"true"` |
 | `TechnicalId` | The Dash0 organization technical ID. | Yes | -- |
-| `Regions` | Comma-separated list of AWS regions in which to enable `AWS/Lambda` metrics streaming (for example `eu-west-1,us-east-1`). | Yes | -- |
-| `Dash0IngressUrl` | Regional Firehose ingress endpoint for your Dash0 organization. Find it under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics`). | Yes | -- |
+| `Regions` | Comma-separated list of AWS regions in which to enable `AWS/Lambda` metrics streaming and (when enabled) Lambda lifecycle event forwarding (for example `eu-west-1,us-east-1`). | Yes | -- |
+| `Dash0RegionalEndpoint` | Regional Dash0 ingress endpoint base URL for your organization. Find it under **Settings > Endpoints > AWS CloudWatch Metrics** in the Dash0 UI (for example `https://ingress.eu-west-1.aws.dash0.com`). Provide only the base URL; the template appends the required paths internally. | Yes | -- |
 
 ## Getting Started
 
@@ -68,10 +71,10 @@ CloudFormation expects `Regions` to be a `CommaDelimitedList`, so the Terraform 
 2. Create a `terraform.tfvars` file with your values (do **not** commit this file):
 
    ```hcl
-   api_key           = "your-dash0-auth-token"
-   technical_id      = "your-organization-technical-id"
-   dash0_ingress_url = "https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics"
-   regions           = ["eu-west-1"]
+   api_key                 = "your-dash0-auth-token"
+   technical_id            = "your-organization-technical-id"
+   dash0_regional_endpoint = "https://ingress.eu-west-1.aws.dash0.com"
+   regions                 = ["eu-west-1"]
    ```
 
 3. Initialize and apply:

--- a/examples/guides/aws_cloudformation_integration/main.tf
+++ b/examples/guides/aws_cloudformation_integration/main.tf
@@ -16,17 +16,19 @@ resource "aws_cloudformation_stack" "dash0_integration" {
   template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation-v2.yaml"
 
   parameters = {
-    ApiKey                   = var.api_key
-    Dataset                  = var.dataset
-    ResourcesInstrumentation = var.resources_instrumentation
-    TechnicalId              = var.technical_id
-    Regions                  = join(",", var.regions)
-    Dash0IngressUrl          = var.dash0_ingress_url
+    ApiKey                       = var.api_key
+    Dataset                      = var.dataset
+    ResourcesInstrumentation     = var.resources_instrumentation
+    CollectLambdaLifecycleEvents = var.collect_lambda_lifecycle_events
+    TechnicalId                  = var.technical_id
+    Regions                      = join(",", var.regions)
+    Dash0RegionalEndpoint        = var.dash0_regional_endpoint
   }
 
   # CAPABILITY_NAMED_IAM: the template creates named IAM roles.
   # CAPABILITY_AUTO_EXPAND: the template contains a nested AWS::CloudFormation::StackSet
-  # that deploys the per-region Lambda metrics streaming resources.
+  # that deploys the per-region Dash0 resources (Lambda metrics streaming and, optionally,
+  # Lambda lifecycle event forwarding).
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }
 

--- a/examples/guides/aws_cloudformation_integration/main.tf
+++ b/examples/guides/aws_cloudformation_integration/main.tf
@@ -13,16 +13,21 @@ provider "aws" {
 
 resource "aws_cloudformation_stack" "dash0_integration" {
   name         = "dash0-integration"
-  template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation.json"
+  template_url = "https://public-integrations-production.eu-west-1.aws.dash0.com.s3.eu-west-1.amazonaws.com/dash0-customer-integration-cloudformation-v2.yaml"
 
   parameters = {
     ApiKey                   = var.api_key
     Dataset                  = var.dataset
     ResourcesInstrumentation = var.resources_instrumentation
     TechnicalId              = var.technical_id
+    Regions                  = join(",", var.regions)
+    Dash0IngressUrl          = var.dash0_ingress_url
   }
 
-  capabilities = ["CAPABILITY_NAMED_IAM"]
+  # CAPABILITY_NAMED_IAM: the template creates named IAM roles.
+  # CAPABILITY_AUTO_EXPAND: the template contains a nested AWS::CloudFormation::StackSet
+  # that deploys the per-region Lambda metrics streaming resources.
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }
 
 output "stack_id" {

--- a/examples/guides/aws_cloudformation_integration/terraform.tfvars.example
+++ b/examples/guides/aws_cloudformation_integration/terraform.tfvars.example
@@ -1,8 +1,12 @@
 # Copy this file to terraform.tfvars and fill in your values.
 # Do NOT commit terraform.tfvars — it contains sensitive credentials.
 
-api_key           = "your-dash0-auth-token"
-dataset           = "default"
-technical_id      = "your-organization-technical-id"
-regions           = ["eu-west-1"]
-dash0_ingress_url = "https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics"
+api_key                 = "your-dash0-auth-token"
+dataset                 = "default"
+technical_id            = "your-organization-technical-id"
+regions                 = ["eu-west-1"]
+dash0_regional_endpoint = "https://ingress.eu-west-1.aws.dash0.com"
+
+# Optional: forward Lambda lifecycle events (UpdateFunctionConfiguration, DeleteFunction).
+# Requires a CloudTrail trail logging management events in the selected regions.
+# collect_lambda_lifecycle_events = "true"

--- a/examples/guides/aws_cloudformation_integration/terraform.tfvars.example
+++ b/examples/guides/aws_cloudformation_integration/terraform.tfvars.example
@@ -1,6 +1,8 @@
 # Copy this file to terraform.tfvars and fill in your values.
 # Do NOT commit terraform.tfvars — it contains sensitive credentials.
 
-api_key      = "your-dash0-auth-token"
-dataset      = "default"
-technical_id = "your-organization-technical-id"
+api_key           = "your-dash0-auth-token"
+dataset           = "default"
+technical_id      = "your-organization-technical-id"
+regions           = ["eu-west-1"]
+dash0_ingress_url = "https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics"

--- a/examples/guides/aws_cloudformation_integration/variables.tf
+++ b/examples/guides/aws_cloudformation_integration/variables.tf
@@ -22,6 +22,12 @@ variable "resources_instrumentation" {
   default     = "true"
 }
 
+variable "collect_lambda_lifecycle_events" {
+  type        = string
+  description = "Whether to forward AWS Lambda lifecycle events (UpdateFunctionConfiguration, DeleteFunction) to Dash0 via EventBridge. Requires a CloudTrail trail logging management events in the selected regions. Must be \"true\" or \"false\"."
+  default     = "true"
+}
+
 variable "technical_id" {
   type        = string
   description = "The Dash0 organization technical ID. Found in the Dash0 UI under Settings > Organization."
@@ -29,11 +35,11 @@ variable "technical_id" {
 
 variable "regions" {
   type        = list(string)
-  description = "AWS regions in which to enable AWS/Lambda metrics streaming. The list is joined into a comma-separated string for CloudFormation."
+  description = "AWS regions in which to enable AWS/Lambda metrics streaming (and Lambda lifecycle event forwarding when enabled). The list is joined into a comma-separated string for CloudFormation."
   default     = ["eu-west-1"]
 }
 
-variable "dash0_ingress_url" {
+variable "dash0_regional_endpoint" {
   type        = string
-  description = "Regional Firehose ingress endpoint for your Dash0 organization. Find it in the Dash0 UI under Settings > Endpoints > AWS CloudWatch Metrics (for example https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics)."
+  description = "Regional Dash0 ingress endpoint base URL for your organization. Find it in the Dash0 UI under Settings > Endpoints > AWS CloudWatch Metrics (for example https://ingress.eu-west-1.aws.dash0.com). Provide only the base URL; the template appends the required paths internally."
 }

--- a/examples/guides/aws_cloudformation_integration/variables.tf
+++ b/examples/guides/aws_cloudformation_integration/variables.tf
@@ -18,11 +18,22 @@ variable "dataset" {
 
 variable "resources_instrumentation" {
   type        = string
-  description = "Whether to enable Lambda and other AWS resource instrumentation."
-  default     = "false"
+  description = "Whether to enable Lambda and other AWS resource instrumentation. Must be \"true\" or \"false\"."
+  default     = "true"
 }
 
 variable "technical_id" {
   type        = string
   description = "The Dash0 organization technical ID. Found in the Dash0 UI under Settings > Organization."
+}
+
+variable "regions" {
+  type        = list(string)
+  description = "AWS regions in which to enable AWS/Lambda metrics streaming. The list is joined into a comma-separated string for CloudFormation."
+  default     = ["eu-west-1"]
+}
+
+variable "dash0_ingress_url" {
+  type        = string
+  description = "Regional Firehose ingress endpoint for your Dash0 organization. Find it in the Dash0 UI under Settings > Endpoints > AWS CloudWatch Metrics (for example https://ingress.eu-west-1.aws.dash0.com/firehose/cwmetrics)."
 }


### PR DESCRIPTION
## Summary

Stacked on top of #76. Updates the AWS CloudFormation integration guide and example to use the new v2 template ([dash0-infrastructure#977](https://github.com/dash0hq/dash0-infrastructure/pull/977)) which adds a nested StackSet that provisions per-region Firehose delivery streams, CloudWatch metric streams and S3 backup buckets for the `AWS/Lambda` namespace.

Changes:

- Point `template_url` at the new `dash0-customer-integration-cloudformation-v2.yaml`.
- Add the two new CloudFormation parameters introduced by v2:
  - `Regions` (`CommaDelimitedList`) — regions in which to enable Lambda metrics streaming. Exposed as a `list(string)` Terraform variable and joined with `join(",", var.regions)`.
  - `Dash0IngressUrl` — regional Firehose ingress endpoint, found in the Dash0 UI under **Settings > Endpoints > AWS CloudWatch Metrics**.
- Add `CAPABILITY_AUTO_EXPAND` to the stack capabilities — required because the v2 template contains a nested `AWS::CloudFormation::StackSet`.
- Update the `ResourcesInstrumentation` default from `"false"` to `"true"` to match the v2 template's new default.
- Document the new Firehose ingress URL prerequisite and the StackSet's retained S3 backup bucket.

Related: [CLO-568](https://linear.app/dash0/issue/CLO-568)

## Test plan

- [x] `terraform fmt -check -recursive examples/guides/aws_cloudformation_integration/`
- [x] `terraform validate` on `examples/guides/aws_cloudformation_integration/` against the AWS provider
- [ ] Manual deploy of the example against a sandbox AWS account once CPA (CLO-524) is live in the target environment

## Notes

The guide still references the production S3 URL. CPA / UI currently still point at the v1 `.json` template — switching to v2 there is a separate follow-up (see dash0-infrastructure#977 description). This PR is intentionally docs/example-only and does not touch the provider's `dash0_aws_integration` resource or the `modules/aws_integration` Terraform module, which talk to the Dash0 API directly and are independent from the CloudFormation path.