### PR TITLE
feat: add support for configuring retry attempts on throttling

### DIFF
--- a/.chloggen/dash0-max-retries.yaml
+++ b/.chloggen/dash0-max-retries.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: provider
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `DASH0_MAX_RETRIES` environment variable
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [141]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Configures the maximum number of retries for failed API requests.
+  Accepted values: 0–5. Default: 3. Behavior before this change: 1 retry.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,20 +22,30 @@ Environment variables take precedence over provider configuration attributes.
 ```sh
 export DASH0_URL="https://api.us-west-2.aws.dash0.com"
 export DASH0_AUTH_TOKEN="auth_xxxx"
+export DASH0_MAX_RETRIES=3  # optional, default: 3, max: 5
 ```
+
+The following environment variables are supported:
+
+| Variable | Required | Description | Default |
+|----------|----------|-------------|---------|
+| `DASH0_URL` | Yes | The base URL of the Dash0 API (e.g. `https://api.us-west-2.aws.dash0.com`). Overrides the `url` provider attribute. | — |
+| `DASH0_AUTH_TOKEN` | Yes | The API auth token for Dash0. Must start with `auth_`. Overrides the `auth_token` provider attribute. | — |
+| `DASH0_MAX_RETRIES` | No | Maximum number of retries for failed API requests (0–5). Overrides the `max_retries` provider attribute. | `3` |
 
 ### Option 2: Provider Configuration
 
-Alternatively, you can configure authentication directly in the provider block:
+Alternatively, you can configure the provider directly in the provider block:
 
 ```terraform
 provider "dash0" {
-  url        = "https://api.us-west-2.aws.dash0.com"
-  auth_token = "auth_xxxx"
+  url         = "https://api.us-west-2.aws.dash0.com"
+  auth_token  = "auth_xxxx"
+  max_retries = 3  # optional, default: 3, max: 5
 }
 ```
 
-**Note:** Environment variables (`DASH0_URL` and `DASH0_AUTH_TOKEN`) will override provider configuration attributes if both are set.
+**Note:** Environment variables take precedence over provider configuration attributes when both are set.
 
 ## Examples
 

--- a/internal/provider/check_rule_resource_acc_test.go
+++ b/internal/provider/check_rule_resource_acc_test.go
@@ -289,6 +289,7 @@ func testAccCheckCheckRuleExists(resourceName string) resource.TestCheckFunc {
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/client/check_rule_test.go
+++ b/internal/provider/client/check_rule_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewDash0Client_CheckRule(t *testing.T) {
 	// Verify client creation works (check rule methods are available on the client)
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test")
+	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }

--- a/internal/provider/client/client_test.go
+++ b/internal/provider/client/client_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestNewDash0Client(t *testing.T) {
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test")
+	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
 func TestNewDash0Client_InvalidToken(t *testing.T) {
-	_, err := NewDash0Client("https://api.example.com", "invalid-token", "test")
+	_, err := NewDash0Client("https://api.example.com", "invalid-token", "test", 3)
 	assert.Error(t, err)
 }

--- a/internal/provider/client/dash0.go
+++ b/internal/provider/client/dash0.go
@@ -12,11 +12,12 @@ type dash0Client struct {
 }
 
 // NewDash0Client creates a new Dash0 API client backed by the shared library.
-func NewDash0Client(url, authToken, version string) (*dash0Client, error) {
+func NewDash0Client(url, authToken, version string, maxRetries int) (*dash0Client, error) {
 	c, err := dash0.NewClient(
 		dash0.WithApiUrl(url),
 		dash0.WithAuthToken(authToken),
 		dash0.WithUserAgent(fmt.Sprintf("Dash0 Terraform Provider/%s", version)),
+		dash0.WithMaxRetries(maxRetries),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/provider/client/recording_rule_test.go
+++ b/internal/provider/client/recording_rule_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewDash0Client_RecordingRule(t *testing.T) {
 	// Verify client creation works (recording rule methods are available on the client)
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test")
+	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }

--- a/internal/provider/client/retry_test.go
+++ b/internal/provider/client/retry_test.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
+)
+
+// throttledServer returns a handler that responds with 429 for the first
+// failCount requests, then responds with 200 and a valid JSON body.
+func throttledServer(failCount int, requestCount *atomic.Int32) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if int(n) <= failCount {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"Dashboard","metadata":{"name":"test"},"spec":{}}`))
+	})
+}
+
+func newTestClient(t *testing.T, serverURL string, maxRetries int) *dash0Client {
+	t.Helper()
+	c, err := dash0.NewClient(
+		dash0.WithApiUrl(serverURL),
+		dash0.WithAuthToken("auth_test-token"),
+		dash0.WithUserAgent("test"),
+		dash0.WithMaxRetries(maxRetries),
+		dash0.WithRetryWaitMin(1*time.Millisecond),
+		dash0.WithRetryWaitMax(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+	return &dash0Client{inner: c}
+}
+
+func TestRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxRetries int
+		failCount  int // number of 429 responses before success
+		wantOK     bool
+		wantTotal  int32 // expected total request count
+	}{
+		{
+			name:       "succeeds on first attempt (no 429s)",
+			maxRetries: 3,
+			failCount:  0,
+			wantOK:     true,
+			wantTotal:  1,
+		},
+		{
+			name:       "succeeds after 1 retry",
+			maxRetries: 3,
+			failCount:  1,
+			wantOK:     true,
+			wantTotal:  2,
+		},
+		{
+			name:       "succeeds after all retries exhausted",
+			maxRetries: 3,
+			failCount:  3,
+			wantOK:     true,
+			wantTotal:  4, // 1 initial + 3 retries
+		},
+		{
+			name:       "fails when retries not enough",
+			maxRetries: 2,
+			failCount:  3,
+			wantOK:     false,
+			wantTotal:  3, // 1 initial + 2 retries, all got 429
+		},
+		{
+			name:       "no retries configured",
+			maxRetries: 0,
+			failCount:  1,
+			wantOK:     false,
+			wantTotal:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(throttledServer(tt.failCount, &requestCount))
+			t.Cleanup(server.Close)
+
+			c := newTestClient(t, server.URL, tt.maxRetries)
+			_, err := c.GetDashboard(t.Context(), "test-origin", "default")
+
+			if tt.wantOK {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), fmt.Sprintf("%d", http.StatusTooManyRequests))
+			}
+			assert.Equal(t, tt.wantTotal, requestCount.Load())
+		})
+	}
+}

--- a/internal/provider/dashboard_resource_acc_test.go
+++ b/internal/provider/dashboard_resource_acc_test.go
@@ -176,6 +176,7 @@ func testAccCheckDashboardExists(resourceName string) resource.TestCheckFunc {
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/notification_channel_resource_acc_test.go
+++ b/internal/provider/notification_channel_resource_acc_test.go
@@ -129,6 +129,7 @@ func testAccCheckNotificationChannelExists(resourceName string) resource.TestChe
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -36,8 +38,9 @@ type dash0Provider struct {
 
 // provider-level config model
 type providerConfigModel struct {
-	URL       types.String `tfsdk:"url"`
-	AuthToken types.String `tfsdk:"auth_token"`
+	URL        types.String `tfsdk:"url"`
+	AuthToken  types.String `tfsdk:"auth_token"`
+	MaxRetries types.Int64  `tfsdk:"max_retries"`
 }
 
 // Metadata returns the provider type name.
@@ -59,6 +62,10 @@ func (p *dash0Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp
 				Optional:    true,
 				Sensitive:   true,
 				Description: "The API auth token for Dash0. Tokens can be created in [Dash0 Settings > Auth Tokens](https://app.dash0.com/settings/auth-tokens). If omitted, the DASH0_AUTH_TOKEN environment variable will be used.",
+			},
+			"max_retries": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of retries for failed API requests (0–5). If omitted, the DASH0_MAX_RETRIES environment variable will be used. Defaults to 3.",
 			},
 		},
 	}
@@ -114,6 +121,33 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	// Resolve max retries: env var > provider attribute > default (3)
+	maxRetries := 3
+	maxRetriesSource := ""
+	if maxRetriesStr := os.Getenv("DASH0_MAX_RETRIES"); maxRetriesStr != "" {
+		parsed, err := strconv.Atoi(maxRetriesStr)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid DASH0_MAX_RETRIES",
+				"The DASH0_MAX_RETRIES environment variable must be a valid integer: "+err.Error(),
+			)
+			return
+		}
+		maxRetries = parsed
+		maxRetriesSource = "DASH0_MAX_RETRIES environment variable"
+	} else if !cfg.MaxRetries.IsNull() && !cfg.MaxRetries.IsUnknown() {
+		maxRetries = int(cfg.MaxRetries.ValueInt64())
+		maxRetriesSource = "max_retries provider attribute"
+	}
+	if maxRetries < 0 || maxRetries > 5 {
+		detail := fmt.Sprintf("max_retries must be between 0 and 5, got: %d", maxRetries)
+		if maxRetriesSource != "" {
+			detail += " (from " + maxRetriesSource + ")"
+		}
+		resp.Diagnostics.AddError("Invalid max_retries", detail)
+		return
+	}
+
 	ctx = tflog.SetField(ctx, "dash0_url", url)
 	ctx = tflog.SetField(ctx, "dash0_auth_token", authToken)
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "dash0_auth_token")
@@ -121,7 +155,7 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 	tflog.Debug(ctx, "Creating Dash0 client")
 
 	// Create dash0Client configuration for data sources and resources
-	dash0Client, err := client.NewDash0Client(url, authToken, p.version)
+	dash0Client, err := client.NewDash0Client(url, authToken, p.version, maxRetries)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Dash0 API Client",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,6 +12,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// providerTestConfig builds a tfsdk.Config for provider tests.
+// Pass nil for any string value to leave it unset (null).
+// Pass nil for maxRetries to leave it unset (null), or a pointer to an int64 to set it.
+func providerTestConfig(url, authToken *string, maxRetries *int64) tfsdk.Config {
+	urlVal := tftypes.NewValue(tftypes.String, nil)
+	if url != nil {
+		urlVal = tftypes.NewValue(tftypes.String, *url)
+	}
+	authTokenVal := tftypes.NewValue(tftypes.String, nil)
+	if authToken != nil {
+		authTokenVal = tftypes.NewValue(tftypes.String, *authToken)
+	}
+	maxRetriesVal := tftypes.NewValue(tftypes.Number, nil)
+	if maxRetries != nil {
+		maxRetriesVal = tftypes.NewValue(tftypes.Number, *maxRetries)
+	}
+
+	return tfsdk.Config{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"url":         tftypes.String,
+				"auth_token":  tftypes.String,
+				"max_retries": tftypes.Number,
+			},
+		}, map[string]tftypes.Value{
+			"url":         urlVal,
+			"auth_token":  authTokenVal,
+			"max_retries": maxRetriesVal,
+		}),
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"url": schema.StringAttribute{
+					Optional: true,
+				},
+				"auth_token": schema.StringAttribute{
+					Optional:  true,
+					Sensitive: true,
+				},
+				"max_retries": schema.Int64Attribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func strPtr(s string) *string { return &s }
+func int64Ptr(n int64) *int64 { return &n }
+
 func TestDash0Provider_Metadata(t *testing.T) {
 	p := &dash0Provider{version: "1.0.0"}
 	resp := &provider.MetadataResponse{}
@@ -32,6 +81,7 @@ func TestDash0Provider_Schema(t *testing.T) {
 	// Verify schema attributes
 	assert.Contains(t, resp.Schema.Attributes, "url")
 	assert.Contains(t, resp.Schema.Attributes, "auth_token")
+	assert.Contains(t, resp.Schema.Attributes, "max_retries")
 
 	// Check specific attribute properties
 	urlAttr := resp.Schema.Attributes["url"].(schema.StringAttribute)
@@ -42,42 +92,18 @@ func TestDash0Provider_Schema(t *testing.T) {
 	assert.True(t, authTokenAttr.Optional)
 	assert.True(t, authTokenAttr.Sensitive)
 	assert.Contains(t, authTokenAttr.Description, "auth token")
+
+	maxRetriesAttr := resp.Schema.Attributes["max_retries"].(schema.Int64Attribute)
+	assert.True(t, maxRetriesAttr.Optional)
+	assert.Contains(t, maxRetriesAttr.Description, "retries")
 }
 
 func TestDash0Provider_Configure_WithEnvironmentVariables(t *testing.T) {
-	// Set environment variables
 	t.Setenv("DASH0_URL", "https://api.example.com")
 	t.Setenv("DASH0_AUTH_TOKEN", "auth_test_token_123")
 
 	p := &dash0Provider{}
-
-	// Create empty config (no provider attributes set)
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, nil),
-			"auth_token": tftypes.NewValue(tftypes.String, nil),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
-	req := provider.ConfigureRequest{
-		Config: config,
-	}
+	req := provider.ConfigureRequest{Config: providerTestConfig(nil, nil, nil)}
 	resp := &provider.ConfigureResponse{}
 
 	p.Configure(context.Background(), req, resp)
@@ -88,38 +114,12 @@ func TestDash0Provider_Configure_WithEnvironmentVariables(t *testing.T) {
 }
 
 func TestDash0Provider_Configure_WithProviderAttributes(t *testing.T) {
-	// Ensure no environment variables are set
 	t.Setenv("DASH0_URL", "")
 	t.Setenv("DASH0_AUTH_TOKEN", "")
 
 	p := &dash0Provider{}
-
-	// Create config with provider attributes
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, "https://api.provider.com"),
-			"auth_token": tftypes.NewValue(tftypes.String, "auth_provider_token_456"),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
 	req := provider.ConfigureRequest{
-		Config: config,
+		Config: providerTestConfig(strPtr("https://api.provider.com"), strPtr("auth_provider_token_456"), nil),
 	}
 	resp := &provider.ConfigureResponse{}
 
@@ -131,82 +131,29 @@ func TestDash0Provider_Configure_WithProviderAttributes(t *testing.T) {
 }
 
 func TestDash0Provider_Configure_EnvironmentVariablesPrecedence(t *testing.T) {
-	// Set environment variables - these should take precedence
 	t.Setenv("DASH0_URL", "https://api.env.com")
 	t.Setenv("DASH0_AUTH_TOKEN", "auth_env_token_789")
 
 	p := &dash0Provider{}
-
-	// Create config with different provider attributes
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, "https://api.provider.com"),
-			"auth_token": tftypes.NewValue(tftypes.String, "auth_provider_token_456"),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
 	req := provider.ConfigureRequest{
-		Config: config,
+		Config: providerTestConfig(strPtr("https://api.provider.com"), strPtr("auth_provider_token_456"), nil),
 	}
 	resp := &provider.ConfigureResponse{}
 
 	p.Configure(context.Background(), req, resp)
 
-	// Environment variables should take precedence, so configuration should succeed
 	assert.False(t, resp.Diagnostics.HasError())
 	assert.NotNil(t, resp.ResourceData)
 	assert.NotNil(t, resp.DataSourceData)
 }
 
 func TestDash0Provider_Configure_MissingURL(t *testing.T) {
-	// Ensure no environment variables are set
 	t.Setenv("DASH0_URL", "")
 	t.Setenv("DASH0_AUTH_TOKEN", "")
 
 	p := &dash0Provider{}
-
-	// Create config with only auth_token
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, nil),
-			"auth_token": tftypes.NewValue(tftypes.String, "auth_token_only"),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
 	req := provider.ConfigureRequest{
-		Config: config,
+		Config: providerTestConfig(nil, strPtr("auth_token_only"), nil),
 	}
 	resp := &provider.ConfigureResponse{}
 
@@ -219,38 +166,12 @@ func TestDash0Provider_Configure_MissingURL(t *testing.T) {
 }
 
 func TestDash0Provider_Configure_MissingAuthToken(t *testing.T) {
-	// Ensure no environment variables are set
 	t.Setenv("DASH0_URL", "")
 	t.Setenv("DASH0_AUTH_TOKEN", "")
 
 	p := &dash0Provider{}
-
-	// Create config with only url
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, "https://api.example.com"),
-			"auth_token": tftypes.NewValue(tftypes.String, nil),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
 	req := provider.ConfigureRequest{
-		Config: config,
+		Config: providerTestConfig(strPtr("https://api.example.com"), nil, nil),
 	}
 	resp := &provider.ConfigureResponse{}
 
@@ -263,45 +184,141 @@ func TestDash0Provider_Configure_MissingAuthToken(t *testing.T) {
 }
 
 func TestDash0Provider_Configure_MissingBoth(t *testing.T) {
-	// Ensure no environment variables are set
 	t.Setenv("DASH0_URL", "")
 	t.Setenv("DASH0_AUTH_TOKEN", "")
 
 	p := &dash0Provider{}
-
-	// Create empty config
-	config := tfsdk.Config{
-		Raw: tftypes.NewValue(tftypes.Object{
-			AttributeTypes: map[string]tftypes.Type{
-				"url":        tftypes.String,
-				"auth_token": tftypes.String,
-			},
-		}, map[string]tftypes.Value{
-			"url":        tftypes.NewValue(tftypes.String, nil),
-			"auth_token": tftypes.NewValue(tftypes.String, nil),
-		}),
-		Schema: schema.Schema{
-			Attributes: map[string]schema.Attribute{
-				"url": schema.StringAttribute{
-					Optional: true,
-				},
-				"auth_token": schema.StringAttribute{
-					Optional:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-
-	req := provider.ConfigureRequest{
-		Config: config,
-	}
+	req := provider.ConfigureRequest{Config: providerTestConfig(nil, nil, nil)}
 	resp := &provider.ConfigureResponse{}
 
 	p.Configure(context.Background(), req, resp)
 
 	assert.True(t, resp.Diagnostics.HasError())
 	assert.Len(t, resp.Diagnostics.Errors(), 2)
+}
+
+func TestDash0Provider_Configure_MaxRetries(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string // DASH0_MAX_RETRIES env var; empty means unset
+		attrValue    *int64 // max_retries provider attribute; nil means unset
+		expectError  bool
+		errorSummary string
+		errorDetail  string
+	}{
+		// --- env var cases ---
+		{
+			name:     "env: valid value 0 (retries disabled)",
+			envValue: "0",
+		},
+		{
+			name:     "env: valid value 3",
+			envValue: "3",
+		},
+		{
+			name:     "env: valid value 5 (maximum)",
+			envValue: "5",
+		},
+		{
+			name:         "env: non-integer value",
+			envValue:     "yolo",
+			expectError:  true,
+			errorSummary: "Invalid DASH0_MAX_RETRIES",
+			errorDetail:  "must be a valid integer",
+		},
+		{
+			name:         "env: floating point value",
+			envValue:     "2.5",
+			expectError:  true,
+			errorSummary: "Invalid DASH0_MAX_RETRIES",
+			errorDetail:  "must be a valid integer",
+		},
+		{
+			name:         "env: negative value",
+			envValue:     "-1",
+			expectError:  true,
+			errorSummary: "Invalid max_retries",
+			errorDetail:  "must be between 0 and 5",
+		},
+		{
+			name:         "env: exceeds maximum",
+			envValue:     "42",
+			expectError:  true,
+			errorSummary: "Invalid max_retries",
+			errorDetail:  "must be between 0 and 5",
+		},
+		// --- provider attribute cases ---
+		{
+			name:      "attr: valid value 0 (retries disabled)",
+			attrValue: int64Ptr(0),
+		},
+		{
+			name:      "attr: valid value 2",
+			attrValue: int64Ptr(2),
+		},
+		{
+			name:      "attr: valid value 5 (maximum)",
+			attrValue: int64Ptr(5),
+		},
+		{
+			name:         "attr: negative value",
+			attrValue:    int64Ptr(-1),
+			expectError:  true,
+			errorSummary: "Invalid max_retries",
+			errorDetail:  "must be between 0 and 5",
+		},
+		{
+			name:         "attr: exceeds maximum",
+			attrValue:    int64Ptr(42),
+			expectError:  true,
+			errorSummary: "Invalid max_retries",
+			errorDetail:  "must be between 0 and 5",
+		},
+		// --- precedence ---
+		{
+			name:      "env takes precedence over attr",
+			envValue:  "1",
+			attrValue: int64Ptr(4),
+		},
+		{
+			name:         "env takes precedence over attr (env invalid)",
+			envValue:     "99",
+			attrValue:    int64Ptr(2),
+			expectError:  true,
+			errorSummary: "Invalid max_retries",
+			errorDetail:  "DASH0_MAX_RETRIES environment variable",
+		},
+		// --- default ---
+		{
+			name: "unset uses default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DASH0_URL", "https://api.example.com")
+			t.Setenv("DASH0_AUTH_TOKEN", "auth_test_token_123")
+			if tt.envValue != "" {
+				t.Setenv("DASH0_MAX_RETRIES", tt.envValue)
+			}
+
+			p := &dash0Provider{}
+			req := provider.ConfigureRequest{Config: providerTestConfig(nil, nil, tt.attrValue)}
+			resp := &provider.ConfigureResponse{}
+
+			p.Configure(context.Background(), req, resp)
+
+			if tt.expectError {
+				assert.True(t, resp.Diagnostics.HasError())
+				require.Len(t, resp.Diagnostics.Errors(), 1)
+				assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), tt.errorSummary)
+				assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), tt.errorDetail)
+			} else {
+				assert.False(t, resp.Diagnostics.HasError())
+				assert.NotNil(t, resp.ResourceData)
+			}
+		})
+	}
 }
 
 func TestDash0Provider_DataSources(t *testing.T) {

--- a/internal/provider/recording_rule_resource_acc_test.go
+++ b/internal/provider/recording_rule_resource_acc_test.go
@@ -159,6 +159,7 @@ func testAccCheckRecordingRuleExists(resourceName string) resource.TestCheckFunc
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/spam_filter_resource_acc_test.go
+++ b/internal/provider/spam_filter_resource_acc_test.go
@@ -162,6 +162,7 @@ func testAccCheckSpamFilterExists(resourceName string) resource.TestCheckFunc {
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/synthetic_check_resource_acc_test.go
+++ b/internal/provider/synthetic_check_resource_acc_test.go
@@ -321,6 +321,7 @@ func testAccCheckSyntheticCheckExists(resourceName string) resource.TestCheckFun
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)

--- a/internal/provider/view_resource_acc_test.go
+++ b/internal/provider/view_resource_acc_test.go
@@ -276,6 +276,7 @@ func testAccCheckViewExists(resourceName string) resource.TestCheckFunc {
 			os.Getenv("DASH0_URL"),
 			os.Getenv("DASH0_AUTH_TOKEN"),
 			"test",
+			3,
 		)
 		if err != nil {
 			return fmt.Errorf("Error creating client: %s", err)


### PR DESCRIPTION
The Dash0 APIs return status code 429 with the RetryAfter header in relative form to signal to the provider to retry later. This change increases the default amount of retries from 1 to 3, and makes them configurable using the `DASH0_MAX_RETRIES` environment variable (max 5 retries).

Closes #110 