### PR TITLE
feat: add a computed url to dashboards, check rules, synthetic checks, and views

### DIFF
--- a/.chloggen/eng-8349-add-a-computed-url-attribute-to-the-dash0_dashboard.yaml
+++ b/.chloggen/eng-8349-add-a-computed-url-attribute-to-the-dash0_dashboard.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: resources
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a computed `url` attribute to the `dash0_dashboard`, `dash0_check_rule`, `dash0_synthetic_check`, and `dash0_view` resources that links to the resource in the Dash0 web app
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [115]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The URL is derived from the configured Dash0 API URL and the resource's server-assigned
+  identifier. For views, the page is selected based on the view's type. It may be empty for
+  self-hosted deployments whose web app uses a custom domain that cannot be derived from the
+  API URL.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/resources/check_rule.md
+++ b/docs/resources/check_rule.md
@@ -56,6 +56,7 @@ EOF
 ### Read-Only
 
 - `origin` (String) A unique identifier for the check rule, automatically generated on creation. Used to reference the check rule for updates, reads, deletes, and imports.
+- `url` (String) The URL to open this check rule in the Dash0 web app, derived from the Dash0 API URL and the check rule's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).
 
 ## Import
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -30,6 +30,7 @@ resource "dash0_dashboard" "my_dashboard" {
 ### Read-Only
 
 - `origin` (String) A unique identifier for the dashboard, automatically generated on creation. Used to reference the dashboard for updates, reads, deletes, and imports.
+- `url` (String) The URL to open this dashboard in the Dash0 web app, derived from the Dash0 API URL and the dashboard's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).
 
 ## Import
 

--- a/docs/resources/synthetic_check.md
+++ b/docs/resources/synthetic_check.md
@@ -30,6 +30,7 @@ resource "dash0_synthetic_check" "my_check" {
 ### Read-Only
 
 - `origin` (String) A unique identifier for the synthetic check, automatically generated on creation. Used to reference the synthetic check for updates, reads, deletes, and imports.
+- `url` (String) The URL to open this synthetic check in the Dash0 web app, derived from the Dash0 API URL and the synthetic check's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).
 
 ## Import
 

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -30,6 +30,7 @@ resource "dash0_view" "my_check" {
 ### Read-Only
 
 - `origin` (String) A unique identifier for the view, automatically generated on creation. Used to reference the view for updates, reads, deletes, and imports.
+- `url` (String) The URL to open this view in the Dash0 web app, derived from the Dash0 API URL and the view's server-assigned identifier. The page is selected based on the view's type (for example the traces explorer for span views). Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain) or the view type has no associated page.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dash0hq/terraform-provider-dash0
 go 1.26.2
 
 require (
-	github.com/dash0hq/dash0-api-client-go v1.12.2
+	github.com/dash0hq/dash0-api-client-go v1.13.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-github.com/dash0hq/dash0-api-client-go v1.12.2 h1:kXw3bHYxQgoAqt/OHiwkMyboJSz/fEQUb/h+HuZO9D0=
-github.com/dash0hq/dash0-api-client-go v1.12.2/go.mod h1:OB1lQ5AKhszeNlNDt+jKgmrzt7iIo/Hqx4ScxiRfoHY=
+github.com/dash0hq/dash0-api-client-go v1.13.0 h1:BKmIuJAokOZR9OMgoU4Gj3PhScUx0n8wGvkZCAKlwjQ=
+github.com/dash0hq/dash0-api-client-go v1.13.0/go.mod h1:OB1lQ5AKhszeNlNDt+jKgmrzt7iIo/Hqx4ScxiRfoHY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
@@ -43,6 +44,7 @@ type checkRuleModel struct {
 	Origin        types.String `tfsdk:"origin"`
 	Dataset       types.String `tfsdk:"dataset"`
 	CheckRuleYaml types.String `tfsdk:"check_rule_yaml"`
+	URL           types.String `tfsdk:"url"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -95,8 +97,35 @@ More information on how Prometheus rules are mapped to Dash0 check rules can be 
 					customplanmodifier.YAMLSemanticEqual(converter.AnnotationSharing),
 				},
 			},
+			"url": schema.StringAttribute{
+				Description: "The URL to open this check rule in the Dash0 web app, derived from the Dash0 API URL and the check rule's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
+}
+
+// setCheckRuleURL resolves the check rule's web app URL by origin and stores it
+// on the model. The URL is best-effort metadata: failures are surfaced as
+// warnings and leave the URL null rather than failing the operation.
+func (r *CheckRuleResource) setCheckRuleURL(ctx context.Context, model *checkRuleModel, diags *diag.Diagnostics) {
+	checkRuleURL, err := r.client.GetCheckRuleURL(ctx, model.Origin.ValueString(), model.Dataset.ValueString())
+	if err != nil {
+		diags.AddWarning(
+			"Unable to determine check rule URL",
+			fmt.Sprintf("The check rule was saved successfully, but its URL could not be determined: %s", err),
+		)
+		model.URL = types.StringNull()
+		return
+	}
+	if checkRuleURL == "" {
+		model.URL = types.StringNull()
+		return
+	}
+	model.URL = types.StringValue(checkRuleURL)
 }
 
 func (r *CheckRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -126,6 +155,9 @@ func (r *CheckRuleResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create check rule, got error: %s", err))
 		return
 	}
+
+	// Resolve the web app URL for the newly created check rule (best-effort).
+	r.setCheckRuleURL(ctx, &model, &resp.Diagnostics)
 
 	tflog.Trace(ctx, "created a check rule resource")
 
@@ -216,6 +248,9 @@ func (r *CheckRuleResource) Update(ctx context.Context, req resource.UpdateReque
 	// Update the existing check rule (dataset changes force recreation via RequiresReplace)
 	// Pass YAML directly to client (the client handles Prometheus->Dash0 conversion)
 	plan.Origin = state.Origin
+	// The check rule's identifier is immutable, so the URL never changes on
+	// update; carry it from state instead of re-resolving it via the API.
+	plan.URL = state.URL
 	err = r.client.UpdateCheckRule(ctx, plan.Origin.ValueString(), plan.CheckRuleYaml.ValueString(), plan.Dataset.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update check rule, got error: %s", err))
@@ -272,6 +307,11 @@ func (r *CheckRuleResource) ImportState(ctx context.Context, req resource.Import
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("origin"), origin)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dataset"), dataset)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("check_rule_yaml"), apiResponseYAML)...)
+
+	// Resolve the web app URL (best-effort).
+	model := checkRuleModel{Origin: types.StringValue(origin), Dataset: types.StringValue(dataset)}
+	r.setCheckRuleURL(ctx, &model, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("url"), model.URL)...)
 }
 
 // injectMetadataName copies metadata.name from sourceYAML into targetYAML when

--- a/internal/provider/check_rule_resource_acc_test.go
+++ b/internal/provider/check_rule_resource_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -81,6 +82,9 @@ func TestAccCheckRuleResource(t *testing.T) {
 					resource.TestCheckResourceAttr(checkRuleResourceName, "dataset", "terraform-test"),
 					resource.TestCheckResourceAttr(checkRuleResourceName, "check_rule_yaml", basicCheckRuleYaml),
 					resource.TestCheckResourceAttrSet(checkRuleResourceName, "origin"),
+					// Verify the computed URL is set and points at the web app deep link
+					resource.TestMatchResourceAttr(checkRuleResourceName, "url",
+						regexp.MustCompile(`^https://app\..+/goto/.+`)),
 				),
 			},
 			// ImportState testing
@@ -109,6 +113,12 @@ func TestAccCheckRuleResource(t *testing.T) {
 					// Verify the check_rule_yaml attribute
 					if yaml := states[0].Attributes["check_rule_yaml"]; yaml == "" {
 						return fmt.Errorf("check_rule_yaml attribute is missing or empty")
+					}
+
+					// Verify the computed url is resolved on import
+					urlPattern := regexp.MustCompile(`^https://app\..+/goto/.+`)
+					if u := states[0].Attributes["url"]; !urlPattern.MatchString(u) {
+						return fmt.Errorf("url attribute %q does not match expected check rule deep link pattern", u)
 					}
 
 					return nil

--- a/internal/provider/check_rule_resource_read_test.go
+++ b/internal/provider/check_rule_resource_read_test.go
@@ -124,6 +124,9 @@ spec:
 					"check_rule_yaml": schema.StringAttribute{
 						Required: true,
 					},
+					"url": schema.StringAttribute{
+						Computed: true,
+					},
 				},
 			}
 
@@ -133,18 +136,22 @@ spec:
 
 			r := &CheckRuleResource{client: testClient}
 
+			testURL := "https://app.dash0.com/goto/alerting/check-rules?check_rule_id=internal-uuid"
+
 			raw := tftypes.NewValue(
 				tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{
 						"origin":          tftypes.String,
 						"dataset":         tftypes.String,
 						"check_rule_yaml": tftypes.String,
+						"url":             tftypes.String,
 					},
 				},
 				map[string]tftypes.Value{
 					"origin":          tftypes.NewValue(tftypes.String, testOrigin),
 					"dataset":         tftypes.NewValue(tftypes.String, testDataset),
 					"check_rule_yaml": tftypes.NewValue(tftypes.String, originalYaml),
+					"url":             tftypes.NewValue(tftypes.String, testURL),
 				},
 			)
 
@@ -172,6 +179,9 @@ spec:
 			} else {
 				assert.Equal(t, originalYaml, resultState.CheckRuleYaml.ValueString())
 			}
+
+			// URL is carried over from prior state (Read does not re-resolve it).
+			assert.Equal(t, testURL, resultState.URL.ValueString())
 
 			hasWarnings := resp.Diagnostics.WarningsCount() > 0
 			assert.Equal(t, tc.expectWarning, hasWarnings)

--- a/internal/provider/check_rule_resource_test.go
+++ b/internal/provider/check_rule_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
 	customplanmodifier "github.com/dash0hq/terraform-provider-dash0/internal/provider/planmodifier"
@@ -33,15 +34,19 @@ spec:
           expr: up == 0
           for: 5m`
 
+	url := "https://app.dash0.com/goto/alerting/check-rules?check_rule_id=internal-uuid"
+
 	m := checkRuleModel{
 		Origin:        types.StringValue(origin),
 		Dataset:       types.StringValue(dataset),
 		CheckRuleYaml: types.StringValue(checkRuleYaml),
+		URL:           types.StringValue(url),
 	}
 
 	assert.Equal(t, origin, m.Origin.ValueString())
 	assert.Equal(t, dataset, m.Dataset.ValueString())
 	assert.Equal(t, checkRuleYaml, m.CheckRuleYaml.ValueString())
+	assert.Equal(t, url, m.URL.ValueString())
 }
 
 func TestNewCheckRuleResource(t *testing.T) {
@@ -76,6 +81,7 @@ func TestCheckRuleResource_Schema(t *testing.T) {
 	assert.Contains(t, resp.Schema.Attributes, "origin")
 	assert.Contains(t, resp.Schema.Attributes, "dataset")
 	assert.Contains(t, resp.Schema.Attributes, "check_rule_yaml")
+	assert.Contains(t, resp.Schema.Attributes, "url")
 
 	// Verify origin is computed
 	originAttr := resp.Schema.Attributes["origin"]
@@ -91,6 +97,11 @@ func TestCheckRuleResource_Schema(t *testing.T) {
 	yamlAttr := resp.Schema.Attributes["check_rule_yaml"]
 	assert.True(t, yamlAttr.IsRequired())
 	assert.False(t, yamlAttr.IsComputed())
+
+	// Verify url is computed
+	urlAttr := resp.Schema.Attributes["url"]
+	assert.True(t, urlAttr.IsComputed())
+	assert.False(t, urlAttr.IsRequired())
 }
 
 func TestCheckRuleResource_Configure(t *testing.T) {
@@ -156,12 +167,14 @@ func TestCheckRuleResource_Create_InvalidYAML(t *testing.T) {
 					"origin":          tftypes.String,
 					"dataset":         tftypes.String,
 					"check_rule_yaml": tftypes.String,
+					"url":             tftypes.String,
 				},
 			},
 			map[string]tftypes.Value{
 				"origin":          tftypes.NewValue(tftypes.String, "test-origin"),
 				"dataset":         tftypes.NewValue(tftypes.String, "test-dataset"),
 				"check_rule_yaml": tftypes.NewValue(tftypes.String, "invalid: yaml: content: ["),
+				"url":             tftypes.NewValue(tftypes.String, nil),
 			},
 		),
 		Schema: schema.Schema{
@@ -175,6 +188,9 @@ func TestCheckRuleResource_Create_InvalidYAML(t *testing.T) {
 				"check_rule_yaml": schema.StringAttribute{
 					Required: true,
 				},
+				"url": schema.StringAttribute{
+					Computed: true,
+				},
 			},
 		},
 	}
@@ -184,6 +200,126 @@ func TestCheckRuleResource_Create_InvalidYAML(t *testing.T) {
 	// Should have error due to invalid YAML
 	assert.True(t, resp.Diagnostics.HasError())
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Invalid YAML")
+}
+
+// testCheckRuleSchema returns the schema (incl. the computed url attribute) used
+// by the lifecycle tests.
+func testCheckRuleSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"origin": schema.StringAttribute{
+				Computed: true,
+			},
+			"dataset": schema.StringAttribute{
+				Required: true,
+			},
+			"check_rule_yaml": schema.StringAttribute{
+				Required: true,
+			},
+			"url": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func TestCheckRuleResource_Create(t *testing.T) {
+	mockClient := new(MockClient)
+	r := &CheckRuleResource{client: mockClient}
+
+	testYaml := `apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rule
+spec:
+  groups:
+    - name: TestGroup
+      rules:
+        - alert: TestAlert
+          expr: up == 0`
+	testDataset := "test-dataset"
+	testURL := "https://app.dash0.com/goto/alerting/check-rules?check_rule_id=internal-uuid"
+
+	plan := tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+			"origin":          tftypes.NewValue(tftypes.String, ""),
+			"dataset":         tftypes.NewValue(tftypes.String, testDataset),
+			"check_rule_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":             tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: testCheckRuleSchema(),
+	}
+	resp := resource.CreateResponse{
+		State: tfsdk.State{Schema: plan.Schema},
+	}
+	req := resource.CreateRequest{Plan: plan}
+
+	mockClient.On("CreateCheckRule", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// After create, the URL is resolved by origin (generated tf_-prefixed value).
+	mockClient.On("GetCheckRuleURL", mock.Anything, mock.Anything, testDataset).Return(testURL, nil)
+
+	r.Create(context.Background(), req, &resp)
+
+	mockClient.AssertExpectations(t)
+	assert.False(t, resp.Diagnostics.HasError())
+
+	var resultState checkRuleModel
+	diags := resp.State.Get(context.Background(), &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, testURL, resultState.URL.ValueString())
+}
+
+func TestCheckRuleResource_Update(t *testing.T) {
+	mockClient := new(MockClient)
+	r := &CheckRuleResource{client: mockClient}
+
+	testOrigin := "test-origin"
+	testDataset := "test-dataset"
+	testYaml := `apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rule
+spec:
+  groups:
+    - name: TestGroup
+      rules:
+        - alert: TestAlert
+          expr: up == 0`
+	testURL := "https://app.dash0.com/goto/alerting/check-rules?check_rule_id=internal-uuid"
+
+	state := tfsdk.State{
+		Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+			"origin":          tftypes.NewValue(tftypes.String, testOrigin),
+			"dataset":         tftypes.NewValue(tftypes.String, testDataset),
+			"check_rule_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":             tftypes.NewValue(tftypes.String, testURL),
+		}),
+		Schema: testCheckRuleSchema(),
+	}
+	plan := tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+			"origin":          tftypes.NewValue(tftypes.String, testOrigin),
+			"dataset":         tftypes.NewValue(tftypes.String, testDataset),
+			"check_rule_yaml": tftypes.NewValue(tftypes.String, testYaml+"\n          for: 5m"),
+			"url":             tftypes.NewValue(tftypes.String, testURL),
+		}),
+		Schema: state.Schema,
+	}
+	req := resource.UpdateRequest{State: state, Plan: plan}
+	resp := resource.UpdateResponse{State: state}
+
+	mockClient.On("UpdateCheckRule", mock.Anything, testOrigin, mock.Anything, testDataset).Return(nil)
+
+	r.Update(context.Background(), req, &resp)
+
+	mockClient.AssertExpectations(t)
+	assert.False(t, resp.Diagnostics.HasError())
+
+	// URL is carried over from prior state (Update does not re-resolve it).
+	var resultState checkRuleModel
+	diags := resp.State.Get(context.Background(), &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 }
 
 func TestCheckRuleResource_SharingAnnotationTriggersReplan(t *testing.T) {
@@ -316,12 +452,14 @@ func TestCheckRuleResource_ReadError(t *testing.T) {
 					"origin":          tftypes.String,
 					"dataset":         tftypes.String,
 					"check_rule_yaml": tftypes.String,
+					"url":             tftypes.String,
 				},
 			},
 			map[string]tftypes.Value{
 				"origin":          tftypes.NewValue(tftypes.String, "test-origin"),
 				"dataset":         tftypes.NewValue(tftypes.String, "test-dataset"),
 				"check_rule_yaml": tftypes.NewValue(tftypes.String, "test-yaml"),
+				"url":             tftypes.NewValue(tftypes.String, nil),
 			},
 		),
 		Schema: schema.Schema{
@@ -334,6 +472,9 @@ func TestCheckRuleResource_ReadError(t *testing.T) {
 				},
 				"check_rule_yaml": schema.StringAttribute{
 					Required: true,
+				},
+				"url": schema.StringAttribute{
+					Computed: true,
 				},
 			},
 		},

--- a/internal/provider/client/check_rule.go
+++ b/internal/provider/client/check_rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	dash0yaml "github.com/dash0hq/dash0-api-client-go/yaml"
 )
 
@@ -68,4 +69,30 @@ func (c *dash0Client) DeleteCheckRule(ctx context.Context, origin string, datase
 
 	tflog.Debug(ctx, fmt.Sprintf("Check rule deleted with origin: %s", origin))
 	return nil
+}
+
+// GetCheckRuleURL builds a deep link to the Dash0 web app for the check rule
+// with the given origin. The internal id is resolved from the list endpoint by
+// matching on origin (see matchOriginID).
+//
+// It returns an empty string (and no error) when the app base URL cannot be
+// derived or the check rule is not present in the list, so that callers can
+// treat the URL as best-effort metadata rather than failing the operation.
+func (c *dash0Client) GetCheckRuleURL(ctx context.Context, origin string, dataset string) (string, error) {
+	items, err := c.inner.ListCheckRules(ctx, &dataset)
+	if err != nil {
+		return "", err
+	}
+
+	id := matchOriginID(items, origin, func(item *dash0.PrometheusAlertRuleApiListItem) (string, *string) {
+		return item.Id, item.Origin
+	})
+	if id == "" {
+		tflog.Warn(ctx, fmt.Sprintf("Check rule with origin %q not found in dataset %q; check rule URL will be empty", origin, dataset))
+		return "", nil
+	}
+
+	checkRuleURL := dash0.DeeplinkURL(c.apiURL, dash0.DeeplinkAssetTypeCheckRule, id)
+	logResolvedURL(ctx, "check rule", origin, checkRuleURL)
+	return checkRuleURL, nil
 }

--- a/internal/provider/client/client.go
+++ b/internal/provider/client/client.go
@@ -3,6 +3,9 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
@@ -14,21 +17,34 @@ type Client interface {
 	GetDashboard(ctx context.Context, origin string, dataset string) (string, error)
 	UpdateDashboard(ctx context.Context, origin string, dashboardJSON string, dataset string) error
 	DeleteDashboard(ctx context.Context, origin string, dataset string) error
+	// GetDashboardURL returns a deep link to the Dash0 web app for the dashboard
+	// with the given origin, or an empty string if it cannot be determined.
+	GetDashboardURL(ctx context.Context, origin string, dataset string) (string, error)
 
 	CreateSyntheticCheck(ctx context.Context, origin string, checkJSON string, dataset string) error
 	GetSyntheticCheck(ctx context.Context, origin string, dataset string) (string, error)
 	UpdateSyntheticCheck(ctx context.Context, origin string, checkJSON string, dataset string) error
 	DeleteSyntheticCheck(ctx context.Context, origin string, dataset string) error
+	// GetSyntheticCheckURL returns a deep link to the Dash0 web app for the
+	// synthetic check with the given origin, or an empty string if it cannot be
+	// determined.
+	GetSyntheticCheckURL(ctx context.Context, origin string, dataset string) (string, error)
 
 	CreateView(ctx context.Context, origin string, viewJSON string, dataset string) error
 	GetView(ctx context.Context, origin string, dataset string) (string, error)
 	UpdateView(ctx context.Context, origin string, viewJSON string, dataset string) error
 	DeleteView(ctx context.Context, origin string, dataset string) error
+	// GetViewURL returns a deep link to the Dash0 web app for the view with the
+	// given origin, or an empty string if it cannot be determined.
+	GetViewURL(ctx context.Context, origin string, dataset string) (string, error)
 
 	CreateCheckRule(ctx context.Context, origin string, ruleYAML string, dataset string) error
 	GetCheckRule(ctx context.Context, origin string, dataset string) (string, error)
 	UpdateCheckRule(ctx context.Context, origin string, ruleYAML string, dataset string) error
 	DeleteCheckRule(ctx context.Context, origin string, dataset string) error
+	// GetCheckRuleURL returns a deep link to the Dash0 web app for the check rule
+	// with the given origin, or an empty string if it cannot be determined.
+	GetCheckRuleURL(ctx context.Context, origin string, dataset string) (string, error)
 
 	CreateRecordingRule(ctx context.Context, origin string, ruleJSON string, dataset string) error
 	GetRecordingRule(ctx context.Context, origin string, dataset string) (string, error)
@@ -48,6 +64,32 @@ type Client interface {
 
 // Ensure dash0Client implements Client
 var _ Client = &dash0Client{}
+
+// matchOriginID returns the server-assigned internal id of the list item whose
+// origin matches the given origin, or an empty string when no item matches.
+//
+// The Dash0 web app addresses assets by their internal id, which the
+// single-asset endpoints do not return (they only echo the origin). The id is
+// therefore resolved from the list endpoint by matching on origin. The accessor
+// extracts the (id, origin) pair from each list item type.
+func matchOriginID[T any](items []*T, origin string, accessor func(*T) (string, *string)) string {
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		id, itemOrigin := accessor(item)
+		if itemOrigin != nil && *itemOrigin == origin {
+			return id
+		}
+	}
+	return ""
+}
+
+// logResolvedURL emits a debug log for a resolved deep link, mirroring the
+// logging done by the per-asset URL resolvers.
+func logResolvedURL(ctx context.Context, assetType, origin, resolvedURL string) {
+	tflog.Debug(ctx, fmt.Sprintf("Resolved %s URL for origin %s: %s", assetType, origin, resolvedURL))
+}
 
 // marshalToJSON marshals a value to a JSON string.
 func marshalToJSON(v interface{}) (string, error) {

--- a/internal/provider/client/dash0.go
+++ b/internal/provider/client/dash0.go
@@ -9,6 +9,9 @@ import (
 // dash0Client wraps the dash0-api-client-go library client.
 type dash0Client struct {
 	inner dash0.Client
+	// apiURL is the configured Dash0 API base URL. It is retained so the
+	// provider can derive the Dash0 web app base URL for dashboard deep links.
+	apiURL string
 }
 
 // NewDash0Client creates a new Dash0 API client backed by the shared library.
@@ -22,5 +25,5 @@ func NewDash0Client(url, authToken, version string, maxRetries int) (*dash0Clien
 	if err != nil {
 		return nil, err
 	}
-	return &dash0Client{inner: c}, nil
+	return &dash0Client{inner: c, apiURL: url}, nil
 }

--- a/internal/provider/client/dashboard.go
+++ b/internal/provider/client/dashboard.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func (c *dash0Client) CreateDashboard(ctx context.Context, origin string, dashboardJSON string, dataset string) error {
@@ -58,4 +60,34 @@ func (c *dash0Client) DeleteDashboard(ctx context.Context, origin string, datase
 
 	tflog.Debug(ctx, fmt.Sprintf("Dashboard deleted with origin: %s", origin))
 	return nil
+}
+
+// GetDashboardURL builds a deep link to the Dash0 web app for the dashboard
+// with the given origin.
+//
+// The web app addresses dashboards by their server-assigned internal id, which
+// is NOT returned by the single-dashboard endpoint (that only echoes the
+// origin). The internal id is therefore resolved from the list endpoint by
+// matching on origin, mirroring how the dash0 CLI builds dashboard URLs.
+//
+// It returns an empty string (and no error) when the app base URL cannot be
+// derived or the dashboard is not present in the list, so that callers can
+// treat the URL as best-effort metadata rather than failing the operation.
+func (c *dash0Client) GetDashboardURL(ctx context.Context, origin string, dataset string) (string, error) {
+	items, err := c.inner.ListDashboards(ctx, &dataset)
+	if err != nil {
+		return "", err
+	}
+
+	id := matchOriginID(items, origin, func(item *dash0.DashboardApiListItem) (string, *string) {
+		return item.Id, item.Origin
+	})
+	if id == "" {
+		tflog.Warn(ctx, fmt.Sprintf("Dashboard with origin %q not found in dataset %q; dashboard URL will be empty", origin, dataset))
+		return "", nil
+	}
+
+	dashboardURL := dash0.DeeplinkURL(c.apiURL, dash0.DeeplinkAssetTypeDashboard, id)
+	logResolvedURL(ctx, "dashboard", origin, dashboardURL)
+	return dashboardURL, nil
 }

--- a/internal/provider/client/dashboard_test.go
+++ b/internal/provider/client/dashboard_test.go
@@ -1,10 +1,15 @@
 package client
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func TestUnmarshalDashboard(t *testing.T) {
@@ -17,4 +22,63 @@ func TestUnmarshalDashboard(t *testing.T) {
 func TestUnmarshalDashboard_Invalid(t *testing.T) {
 	_, err := unmarshalDashboard("not json")
 	assert.Error(t, err)
+}
+
+func TestMatchOriginID(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	accessor := func(item *dash0.DashboardApiListItem) (string, *string) {
+		return item.Id, item.Origin
+	}
+	items := []*dash0.DashboardApiListItem{
+		nil, // tolerate nil entries
+		{Id: "11111111-1111-1111-1111-111111111111", Origin: strPtr("tf_abc")},
+		{Id: "22222222-2222-2222-2222-222222222222", Origin: nil}, // UI-created, no origin
+		{Id: "33333333-3333-3333-3333-333333333333", Origin: strPtr("tf_target")},
+	}
+
+	t.Run("match by origin returns the internal id", func(t *testing.T) {
+		assert.Equal(t, "33333333-3333-3333-3333-333333333333", matchOriginID(items, "tf_target", accessor))
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		assert.Equal(t, "", matchOriginID(items, "tf_missing", accessor))
+	})
+}
+
+// TestGetDashboardURL verifies that GetDashboardURL resolves the internal id by
+// matching on origin and returns the library-built deep link. The host
+// derivation and URL format themselves are the responsibility of the
+// dash0-api-client-go library and are covered by its own tests.
+func TestGetDashboardURL(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]dash0.DashboardApiListItem{
+			{Id: "11111111-1111-1111-1111-111111111111", Origin: strPtr("tf_other")},
+			{Id: "33333333-3333-3333-3333-333333333333", Origin: strPtr("tf_target")},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	inner, err := dash0.NewClient(
+		dash0.WithApiUrl(server.URL),
+		dash0.WithAuthToken("auth_test-token"),
+		dash0.WithUserAgent("test"),
+	)
+	require.NoError(t, err)
+
+	// inner points at the test server; apiURL drives the deep link host.
+	c := &dash0Client{inner: inner, apiURL: "https://api.us-west-2.aws.dash0.com"}
+
+	t.Run("match by origin returns the library deep link", func(t *testing.T) {
+		got, err := c.GetDashboardURL(t.Context(), "tf_target", "default")
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.dash0.com/goto/dashboards?dashboard_id=33333333-3333-3333-3333-333333333333", got)
+	})
+
+	t.Run("no match returns empty string and no error", func(t *testing.T) {
+		got, err := c.GetDashboardURL(t.Context(), "tf_missing", "default")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
 }

--- a/internal/provider/client/synthetic_check.go
+++ b/internal/provider/client/synthetic_check.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func (c *dash0Client) CreateSyntheticCheck(ctx context.Context, origin string, checkJSON string, dataset string) error {
@@ -57,4 +59,30 @@ func (c *dash0Client) DeleteSyntheticCheck(ctx context.Context, origin string, d
 
 	tflog.Debug(ctx, fmt.Sprintf("Synthetic check deleted with origin: %s", origin))
 	return nil
+}
+
+// GetSyntheticCheckURL builds a deep link to the Dash0 web app for the synthetic
+// check with the given origin. The internal id is resolved from the list
+// endpoint by matching on origin (see matchOriginID).
+//
+// It returns an empty string (and no error) when the app base URL cannot be
+// derived or the synthetic check is not present in the list, so that callers
+// can treat the URL as best-effort metadata rather than failing the operation.
+func (c *dash0Client) GetSyntheticCheckURL(ctx context.Context, origin string, dataset string) (string, error) {
+	items, err := c.inner.ListSyntheticChecks(ctx, &dataset)
+	if err != nil {
+		return "", err
+	}
+
+	id := matchOriginID(items, origin, func(item *dash0.SyntheticChecksApiListItem) (string, *string) {
+		return item.Id, item.Origin
+	})
+	if id == "" {
+		tflog.Warn(ctx, fmt.Sprintf("Synthetic check with origin %q not found in dataset %q; synthetic check URL will be empty", origin, dataset))
+		return "", nil
+	}
+
+	syntheticCheckURL := dash0.DeeplinkURL(c.apiURL, dash0.DeeplinkAssetTypeSyntheticCheck, id)
+	logResolvedURL(ctx, "synthetic check", origin, syntheticCheckURL)
+	return syntheticCheckURL, nil
 }

--- a/internal/provider/client/view.go
+++ b/internal/provider/client/view.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func (c *dash0Client) CreateView(ctx context.Context, origin string, viewJSON string, dataset string) error {
@@ -57,4 +59,36 @@ func (c *dash0Client) DeleteView(ctx context.Context, origin string, dataset str
 
 	tflog.Debug(ctx, fmt.Sprintf("View deleted with origin: %s", origin))
 	return nil
+}
+
+// GetViewURL builds a deep link to the Dash0 web app for the view with the
+// given origin. The internal id and view type are resolved from the list
+// endpoint by matching on origin; the view type selects the correct page (for
+// example the traces explorer for span views).
+//
+// It returns an empty string (and no error) when the app base URL cannot be
+// derived, the view is not present in the list, or the view type has no
+// associated page, so that callers can treat the URL as best-effort metadata
+// rather than failing the operation.
+func (c *dash0Client) GetViewURL(ctx context.Context, origin string, dataset string) (string, error) {
+	items, err := c.inner.ListViews(ctx, &dataset)
+	if err != nil {
+		return "", err
+	}
+
+	var matched *dash0.ViewApiListItem
+	for _, item := range items {
+		if item != nil && item.Origin != nil && *item.Origin == origin {
+			matched = item
+			break
+		}
+	}
+	if matched == nil {
+		tflog.Warn(ctx, fmt.Sprintf("View with origin %q not found in dataset %q; view URL will be empty", origin, dataset))
+		return "", nil
+	}
+
+	viewURL := dash0.ViewDeeplinkURL(c.apiURL, matched.Type, matched.Id)
+	logResolvedURL(ctx, "view", origin, viewURL)
+	return viewURL, nil
 }

--- a/internal/provider/client_mock.go
+++ b/internal/provider/client_mock.go
@@ -31,6 +31,11 @@ func (m *MockClient) DeleteDashboard(ctx context.Context, origin string, dataset
 	return args.Error(0)
 }
 
+func (m *MockClient) GetDashboardURL(ctx context.Context, origin string, dataset string) (string, error) {
+	args := m.Called(ctx, origin, dataset)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockClient) CreateSyntheticCheck(ctx context.Context, origin string, checkJSON string, dataset string) error {
 	args := m.Called(ctx, origin, checkJSON, dataset)
 	return args.Error(0)
@@ -49,6 +54,11 @@ func (m *MockClient) UpdateSyntheticCheck(ctx context.Context, origin string, ch
 func (m *MockClient) DeleteSyntheticCheck(ctx context.Context, origin string, dataset string) error {
 	args := m.Called(ctx, origin, dataset)
 	return args.Error(0)
+}
+
+func (m *MockClient) GetSyntheticCheckURL(ctx context.Context, origin string, dataset string) (string, error) {
+	args := m.Called(ctx, origin, dataset)
+	return args.String(0), args.Error(1)
 }
 
 func (m *MockClient) CreateView(ctx context.Context, origin string, viewJSON string, dataset string) error {
@@ -71,6 +81,11 @@ func (m *MockClient) DeleteView(ctx context.Context, origin string, dataset stri
 	return args.Error(0)
 }
 
+func (m *MockClient) GetViewURL(ctx context.Context, origin string, dataset string) (string, error) {
+	args := m.Called(ctx, origin, dataset)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockClient) CreateCheckRule(ctx context.Context, origin string, ruleYAML string, dataset string) error {
 	args := m.Called(ctx, origin, ruleYAML, dataset)
 	return args.Error(0)
@@ -89,6 +104,11 @@ func (m *MockClient) UpdateCheckRule(ctx context.Context, origin string, ruleYAM
 func (m *MockClient) DeleteCheckRule(ctx context.Context, origin string, dataset string) error {
 	args := m.Called(ctx, origin, dataset)
 	return args.Error(0)
+}
+
+func (m *MockClient) GetCheckRuleURL(ctx context.Context, origin string, dataset string) (string, error) {
+	args := m.Called(ctx, origin, dataset)
+	return args.String(0), args.Error(1)
 }
 
 func (m *MockClient) CreateRecordingRule(ctx context.Context, origin string, ruleJSON string, dataset string) error {

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
@@ -43,6 +44,7 @@ type dashboardModel struct {
 	Origin        types.String `tfsdk:"origin"`
 	Dataset       types.String `tfsdk:"dataset"`
 	DashboardYaml types.String `tfsdk:"dashboard_yaml"`
+	URL           types.String `tfsdk:"url"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -92,8 +94,35 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					customplanmodifier.YAMLSemanticEqual(converter.AnnotationSharing, converter.AnnotationFolderPath),
 				},
 			},
+			"url": schema.StringAttribute{
+				Description: "The URL to open this dashboard in the Dash0 web app, derived from the Dash0 API URL and the dashboard's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
+}
+
+// setDashboardURL resolves the dashboard's web app URL by origin and stores it
+// on the model. The URL is best-effort metadata: failures are surfaced as
+// warnings and leave the URL null rather than failing the operation.
+func (r *DashboardResource) setDashboardURL(ctx context.Context, model *dashboardModel, diags *diag.Diagnostics) {
+	dashboardURL, err := r.client.GetDashboardURL(ctx, model.Origin.ValueString(), model.Dataset.ValueString())
+	if err != nil {
+		diags.AddWarning(
+			"Unable to determine dashboard URL",
+			fmt.Sprintf("The dashboard was saved successfully, but its URL could not be determined: %s", err),
+		)
+		model.URL = types.StringNull()
+		return
+	}
+	if dashboardURL == "" {
+		model.URL = types.StringNull()
+		return
+	}
+	model.URL = types.StringValue(dashboardURL)
 }
 
 func (r *DashboardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -129,6 +158,9 @@ func (r *DashboardResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dashboard, got error: %s", err))
 		return
 	}
+
+	// Resolve the web app URL for the newly created dashboard (best-effort).
+	r.setDashboardURL(ctx, &model, &resp.Diagnostics)
 
 	tflog.Trace(ctx, "created a dashboard resource")
 
@@ -217,6 +249,9 @@ func (r *DashboardResource) Update(ctx context.Context, req resource.UpdateReque
 
 	// Update the existing dashboard (dataset changes force recreation via RequiresReplace)
 	plan.Origin = state.Origin
+	// The dashboard's identifier is immutable, so the URL never changes on
+	// update; carry it from state instead of re-resolving it via the API.
+	plan.URL = state.URL
 	err = r.client.UpdateDashboard(ctx, plan.Origin.ValueString(), jsonBody, plan.Dataset.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dashboard, got error: %s", err))
@@ -273,4 +308,9 @@ func (r *DashboardResource) ImportState(ctx context.Context, req resource.Import
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("origin"), origin)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dataset"), dataset)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dashboard_yaml"), apiResponseJSON)...)
+
+	// Resolve the web app URL (best-effort).
+	model := dashboardModel{Origin: types.StringValue(origin), Dataset: types.StringValue(dataset)}
+	r.setDashboardURL(ctx, &model, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("url"), model.URL)...)
 }

--- a/internal/provider/dashboard_resource_acc_test.go
+++ b/internal/provider/dashboard_resource_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -66,6 +67,9 @@ func TestAccDashboardResource(t *testing.T) {
 					resource.TestCheckResourceAttr(dashboardResourceName, "dataset", "default"),
 					resource.TestCheckResourceAttr(dashboardResourceName, "dashboard_yaml", basicDashboardYaml),
 					resource.TestCheckResourceAttrSet(dashboardResourceName, "origin"),
+					// Verify the computed URL is set and points at the web app deep link
+					resource.TestMatchResourceAttr(dashboardResourceName, "url",
+						regexp.MustCompile(`^https://app\..+/goto/dashboards\?dashboard_id=.+`)),
 				),
 			},
 			// ImportState testing
@@ -94,6 +98,12 @@ func TestAccDashboardResource(t *testing.T) {
 					// Verify the dashboard_yaml attribute
 					if yaml := states[0].Attributes["dashboard_yaml"]; yaml == "" {
 						return fmt.Errorf("dashboard_yaml attribute is missing or empty")
+					}
+
+					// Verify the computed url is resolved on import
+					urlPattern := regexp.MustCompile(`^https://app\..+/goto/dashboards\?dashboard_id=.+`)
+					if u := states[0].Attributes["url"]; !urlPattern.MatchString(u) {
+						return fmt.Errorf("url attribute %q does not match expected dashboard deep link pattern", u)
 					}
 
 					return nil

--- a/internal/provider/dashboard_resource_read_test.go
+++ b/internal/provider/dashboard_resource_read_test.go
@@ -104,6 +104,9 @@ spec:
 					"dashboard_yaml": schema.StringAttribute{
 						Required: true,
 					},
+					"url": schema.StringAttribute{
+						Computed: true,
+					},
 				},
 			}
 
@@ -122,12 +125,14 @@ spec:
 						"origin":         tftypes.String,
 						"dataset":        tftypes.String,
 						"dashboard_yaml": tftypes.String,
+						"url":            tftypes.String,
 					},
 				},
 				map[string]tftypes.Value{
 					"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 					"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 					"dashboard_yaml": tftypes.NewValue(tftypes.String, originalYaml),
+					"url":            tftypes.NewValue(tftypes.String, "https://app.dash0.com/goto/dashboards?dashboard_id=internal-uuid"),
 				},
 			)
 

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -39,11 +39,13 @@ func TestDashboardResource_Schema(t *testing.T) {
 	assert.Contains(t, resp.Schema.Attributes, "origin")
 	assert.Contains(t, resp.Schema.Attributes, "dataset")
 	assert.Contains(t, resp.Schema.Attributes, "dashboard_yaml")
+	assert.Contains(t, resp.Schema.Attributes, "url")
 
 	// Check specific attribute properties
 	assert.True(t, resp.Schema.Attributes["origin"].(schema.StringAttribute).Computed)
 	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Required)
 	assert.True(t, resp.Schema.Attributes["dashboard_yaml"].(schema.StringAttribute).Required)
+	assert.True(t, resp.Schema.Attributes["url"].(schema.StringAttribute).Computed)
 }
 
 func TestDashboardResource_Configure(t *testing.T) {
@@ -82,6 +84,7 @@ func TestDashboardResource_Create(t *testing.T) {
 			"origin":         tftypes.NewValue(tftypes.String, ""),
 			"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 			"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":            tftypes.NewValue(tftypes.String, nil),
 		}),
 		Schema: schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -93,6 +96,9 @@ func TestDashboardResource_Create(t *testing.T) {
 				},
 				"dashboard_yaml": schema.StringAttribute{
 					Required: true,
+				},
+				"url": schema.StringAttribute{
+					Computed: true,
 				},
 			},
 		},
@@ -111,8 +117,12 @@ func TestDashboardResource_Create(t *testing.T) {
 		State: state,
 	}
 
+	testURL := "https://app.dash0.com/goto/dashboards?dashboard_id=internal-uuid"
+
 	// Setup mock expectations - CreateDashboard(ctx, origin, jsonBody, dataset)
 	mockClient.On("CreateDashboard", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// After create, the URL is resolved by origin (generated tf_-prefixed value).
+	mockClient.On("GetDashboardURL", mock.Anything, mock.Anything, testDataset).Return(testURL, nil)
 
 	// Execute the create operation
 	r.Create(context.Background(), req, &resp)
@@ -120,6 +130,12 @@ func TestDashboardResource_Create(t *testing.T) {
 	// Verify expectations
 	mockClient.AssertExpectations(t)
 	assert.False(t, resp.Diagnostics.HasError())
+
+	// Verify the resolved URL was written to state
+	var resultState dashboardModel
+	diags := resp.State.Get(context.Background(), &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 }
 
 func TestDashboardResource_Read(t *testing.T) {
@@ -144,8 +160,13 @@ func TestDashboardResource_Read(t *testing.T) {
 			"dashboard_yaml": schema.StringAttribute{
 				Required: true,
 			},
+			"url": schema.StringAttribute{
+				Computed: true,
+			},
 		},
 	}
+
+	testURL := "https://app.dash0.com/goto/dashboards?dashboard_id=internal-uuid"
 
 	// Setup state
 	state := tfsdk.State{
@@ -153,6 +174,7 @@ func TestDashboardResource_Read(t *testing.T) {
 			"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 			"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 			"dashboard_yaml": tftypes.NewValue(tftypes.String, "old yaml"),
+			"url":            tftypes.NewValue(tftypes.String, testURL),
 		}),
 		Schema: stateSchema,
 	}
@@ -186,6 +208,8 @@ func TestDashboardResource_Read(t *testing.T) {
 	assert.Equal(t, testOrigin, resultState.Origin.ValueString())
 	assert.Equal(t, testDataset, resultState.Dataset.ValueString())
 	assert.Equal(t, testYaml, resultState.DashboardYaml.ValueString())
+	// URL is carried over from prior state (Read does not re-resolve it).
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 
 	// Test with API error
 	mockClient = new(MockClient)
@@ -218,12 +242,15 @@ func TestDashboardResource_Update(t *testing.T) {
 		mockClient := new(MockClient)
 		r := &DashboardResource{client: mockClient}
 
+		testURL := "https://app.dash0.com/goto/dashboards?dashboard_id=internal-uuid"
+
 		// Create state
 		state := tfsdk.State{
 			Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
 				"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 				"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
+				"url":            tftypes.NewValue(tftypes.String, testURL),
 			}),
 			Schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -235,6 +262,9 @@ func TestDashboardResource_Update(t *testing.T) {
 					},
 					"dashboard_yaml": schema.StringAttribute{
 						Required: true,
+					},
+					"url": schema.StringAttribute{
+						Computed: true,
 					},
 				},
 			},
@@ -248,6 +278,7 @@ func TestDashboardResource_Update(t *testing.T) {
 				"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 				"dashboard_yaml": tftypes.NewValue(tftypes.String, updatedYaml),
+				"url":            tftypes.NewValue(tftypes.String, testURL),
 			}),
 			Schema: state.Schema,
 		}
@@ -270,6 +301,12 @@ func TestDashboardResource_Update(t *testing.T) {
 		// Verify expectations
 		mockClient.AssertExpectations(t)
 		assert.False(t, resp.Diagnostics.HasError())
+
+		// URL is carried over from prior state (Update does not re-resolve it).
+		var resultState dashboardModel
+		diags := resp.State.Get(context.Background(), &resultState)
+		require.False(t, diags.HasError(), "state cannot be unmarshalled")
+		assert.Equal(t, testURL, resultState.URL.ValueString())
 	})
 
 	// Test 2: Invalid YAML
@@ -284,6 +321,7 @@ func TestDashboardResource_Update(t *testing.T) {
 				"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 				"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
+				"url":            tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -296,6 +334,9 @@ func TestDashboardResource_Update(t *testing.T) {
 					"dashboard_yaml": schema.StringAttribute{
 						Required: true,
 					},
+					"url": schema.StringAttribute{
+						Computed: true,
+					},
 				},
 			},
 		}
@@ -306,6 +347,7 @@ func TestDashboardResource_Update(t *testing.T) {
 				"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 				"dashboard_yaml": tftypes.NewValue(tftypes.String, "invalid: yaml: : :"),
+				"url":            tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: state.Schema,
 		}
@@ -701,6 +743,7 @@ func TestDashboardResource_Delete(t *testing.T) {
 			"origin":         tftypes.NewValue(tftypes.String, testOrigin),
 			"dataset":        tftypes.NewValue(tftypes.String, testDataset),
 			"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":            tftypes.NewValue(tftypes.String, "https://app.dash0.com/goto/dashboards?dashboard_id=internal-uuid"),
 		}),
 		Schema: schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -712,6 +755,9 @@ func TestDashboardResource_Delete(t *testing.T) {
 				},
 				"dashboard_yaml": schema.StringAttribute{
 					Required: true,
+				},
+				"url": schema.StringAttribute{
+					Computed: true,
 				},
 			},
 		},

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
@@ -43,6 +44,7 @@ type syntheticCheckModel struct {
 	Origin             types.String `tfsdk:"origin"`
 	Dataset            types.String `tfsdk:"dataset"`
 	SyntheticCheckYaml types.String `tfsdk:"synthetic_check_yaml"`
+	URL                types.String `tfsdk:"url"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -92,8 +94,36 @@ func (r *SyntheticCheckResource) Schema(_ context.Context, _ resource.SchemaRequ
 					customplanmodifier.YAMLSemanticEqual(converter.AnnotationSharing),
 				},
 			},
+			"url": schema.StringAttribute{
+				Description: "The URL to open this synthetic check in the Dash0 web app, derived from the Dash0 API URL and the synthetic check's server-assigned identifier. Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
+}
+
+// setSyntheticCheckURL resolves the synthetic check's web app URL by origin and
+// stores it on the model. The URL is best-effort metadata: failures are
+// surfaced as warnings and leave the URL null rather than failing the
+// operation.
+func (r *SyntheticCheckResource) setSyntheticCheckURL(ctx context.Context, model *syntheticCheckModel, diags *diag.Diagnostics) {
+	syntheticCheckURL, err := r.client.GetSyntheticCheckURL(ctx, model.Origin.ValueString(), model.Dataset.ValueString())
+	if err != nil {
+		diags.AddWarning(
+			"Unable to determine synthetic check URL",
+			fmt.Sprintf("The synthetic check was saved successfully, but its URL could not be determined: %s", err),
+		)
+		model.URL = types.StringNull()
+		return
+	}
+	if syntheticCheckURL == "" {
+		model.URL = types.StringNull()
+		return
+	}
+	model.URL = types.StringValue(syntheticCheckURL)
 }
 
 func (r *SyntheticCheckResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -129,6 +159,9 @@ func (r *SyntheticCheckResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create synthetic check, got error: %s", err))
 		return
 	}
+
+	// Resolve the web app URL for the newly created synthetic check (best-effort).
+	r.setSyntheticCheckURL(ctx, &model, &resp.Diagnostics)
 
 	tflog.Trace(ctx, "created a synthetic check resource")
 
@@ -217,6 +250,9 @@ func (r *SyntheticCheckResource) Update(ctx context.Context, req resource.Update
 
 	// Update the existing synthetic check (dataset changes force recreation via RequiresReplace)
 	plan.Origin = state.Origin
+	// The synthetic check's identifier is immutable, so the URL never changes on
+	// update; carry it from state instead of re-resolving it via the API.
+	plan.URL = state.URL
 	err = r.client.UpdateSyntheticCheck(ctx, plan.Origin.ValueString(), jsonBody, plan.Dataset.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update synthetic check, got error: %s", err))
@@ -273,4 +309,9 @@ func (r *SyntheticCheckResource) ImportState(ctx context.Context, req resource.I
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("origin"), origin)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dataset"), dataset)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("synthetic_check_yaml"), apiResponseJSON)...)
+
+	// Resolve the web app URL (best-effort).
+	model := syntheticCheckModel{Origin: types.StringValue(origin), Dataset: types.StringValue(dataset)}
+	r.setSyntheticCheckURL(ctx, &model, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("url"), model.URL)...)
 }

--- a/internal/provider/synthetic_check_resource_acc_test.go
+++ b/internal/provider/synthetic_check_resource_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -152,6 +153,9 @@ func TestAccSyntheticCheckResource(t *testing.T) {
 					resource.TestCheckResourceAttr(syntheticCheckResourceName, "dataset", "terraform-test"),
 					resource.TestCheckResourceAttr(syntheticCheckResourceName, "synthetic_check_yaml", basicSyntheticCheckYaml),
 					resource.TestCheckResourceAttrSet(syntheticCheckResourceName, "origin"),
+					// Verify the computed URL is set and points at the web app deep link
+					resource.TestMatchResourceAttr(syntheticCheckResourceName, "url",
+						regexp.MustCompile(`^https://app\..+/goto/.+`)),
 				),
 			},
 			// ImportState testing
@@ -180,6 +184,12 @@ func TestAccSyntheticCheckResource(t *testing.T) {
 					// Verify the synthetic_check_yaml attribute
 					if yaml := states[0].Attributes["synthetic_check_yaml"]; yaml == "" {
 						return fmt.Errorf("synthetic_check_yaml attribute is missing or empty")
+					}
+
+					// Verify the computed url is resolved on import
+					urlPattern := regexp.MustCompile(`^https://app\..+/goto/.+`)
+					if u := states[0].Attributes["url"]; !urlPattern.MatchString(u) {
+						return fmt.Errorf("url attribute %q does not match expected synthetic check deep link pattern", u)
 					}
 
 					return nil

--- a/internal/provider/synthetic_check_resource_read_test.go
+++ b/internal/provider/synthetic_check_resource_read_test.go
@@ -122,6 +122,8 @@ spec:
 				client: mockClient,
 			}
 
+			testURL := "https://app.dash0.com/goto/alerting/synthetics?check_id=internal-uuid"
+
 			// Setup request with current state
 			req := resource.ReadRequest{
 				State: tfsdk.State{
@@ -130,11 +132,13 @@ spec:
 							"origin":               tftypes.String,
 							"dataset":              tftypes.String,
 							"synthetic_check_yaml": tftypes.String,
+							"url":                  tftypes.String,
 						},
 					}, map[string]tftypes.Value{
 						"origin":               tftypes.NewValue(tftypes.String, "test-origin"),
 						"dataset":              tftypes.NewValue(tftypes.String, "test-dataset"),
 						"synthetic_check_yaml": tftypes.NewValue(tftypes.String, tt.currentState),
+						"url":                  tftypes.NewValue(tftypes.String, testURL),
 					}),
 					Schema: testSyntheticCheckSchema(),
 				},
@@ -170,6 +174,9 @@ spec:
 					assert.Equal(t, tt.currentState, state.SyntheticCheckYaml.ValueString(),
 						"State should not have been updated")
 				}
+
+				// URL is carried over from prior state (Read does not re-resolve it).
+				assert.Equal(t, testURL, state.URL.ValueString())
 			}
 		})
 	}

--- a/internal/provider/synthetic_check_resource_test.go
+++ b/internal/provider/synthetic_check_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
 	customplanmodifier "github.com/dash0hq/terraform-provider-dash0/internal/provider/planmodifier"
@@ -46,6 +47,7 @@ func TestSyntheticCheckResource_Schema(t *testing.T) {
 	assert.Contains(t, attrs, "origin")
 	assert.Contains(t, attrs, "dataset")
 	assert.Contains(t, attrs, "synthetic_check_yaml")
+	assert.Contains(t, attrs, "url")
 
 	// Check origin is computed
 	originAttr := attrs["origin"].(schema.StringAttribute)
@@ -58,6 +60,10 @@ func TestSyntheticCheckResource_Schema(t *testing.T) {
 	// Check synthetic_check_yaml is required
 	checkYamlAttr := attrs["synthetic_check_yaml"].(schema.StringAttribute)
 	assert.True(t, checkYamlAttr.Required)
+
+	// Check url is computed
+	urlAttr := attrs["url"].(schema.StringAttribute)
+	assert.True(t, urlAttr.Computed)
 }
 
 func TestSyntheticCheckResource_Create(t *testing.T) {
@@ -68,6 +74,8 @@ func TestSyntheticCheckResource_Create(t *testing.T) {
 		client: mockClient,
 	}
 
+	testURL := "https://app.dash0.com/goto/alerting/synthetics?check_id=internal-uuid"
+
 	// Setup request
 	req := resource.CreateRequest{
 		Plan: tfsdk.Plan{
@@ -76,6 +84,7 @@ func TestSyntheticCheckResource_Create(t *testing.T) {
 					"origin":               tftypes.String,
 					"dataset":              tftypes.String,
 					"synthetic_check_yaml": tftypes.String,
+					"url":                  tftypes.String,
 				},
 			}, map[string]tftypes.Value{
 				"origin":  tftypes.NewValue(tftypes.String, nil),
@@ -91,6 +100,7 @@ spec:
     spec:
       request:
         url: https://www.example.com`),
+				"url": tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: testSyntheticCheckSchema(),
 		},
@@ -104,6 +114,8 @@ spec:
 
 	// Setup mock expectations - CreateSyntheticCheck(ctx, origin, jsonBody, dataset)
 	mockClient.On("CreateSyntheticCheck", ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// After create, the URL is resolved by origin (generated tf_-prefixed value).
+	mockClient.On("GetSyntheticCheckURL", ctx, mock.Anything, "test-dataset").Return(testURL, nil)
 
 	// Execute
 	r.Create(ctx, req, resp)
@@ -111,6 +123,12 @@ spec:
 	// Verify
 	assert.False(t, resp.Diagnostics.HasError())
 	mockClient.AssertExpectations(t)
+
+	// Verify the resolved URL was written to state
+	var resultState syntheticCheckModel
+	diags := resp.State.Get(ctx, &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 }
 
 func TestSyntheticCheckResource_CreateWithError(t *testing.T) {
@@ -129,6 +147,7 @@ func TestSyntheticCheckResource_CreateWithError(t *testing.T) {
 					"origin":               tftypes.String,
 					"dataset":              tftypes.String,
 					"synthetic_check_yaml": tftypes.String,
+					"url":                  tftypes.String,
 				},
 			}, map[string]tftypes.Value{
 				"origin":  tftypes.NewValue(tftypes.String, nil),
@@ -137,6 +156,7 @@ func TestSyntheticCheckResource_CreateWithError(t *testing.T) {
 kind: Dash0SyntheticCheck
 metadata:
   name: examplecom`),
+				"url": tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: testSyntheticCheckSchema(),
 		},
@@ -175,11 +195,13 @@ func TestSyntheticCheckResource_Delete(t *testing.T) {
 					"origin":               tftypes.String,
 					"dataset":              tftypes.String,
 					"synthetic_check_yaml": tftypes.String,
+					"url":                  tftypes.String,
 				},
 			}, map[string]tftypes.Value{
 				"origin":               tftypes.NewValue(tftypes.String, "test-origin"),
 				"dataset":              tftypes.NewValue(tftypes.String, "test-dataset"),
 				"synthetic_check_yaml": tftypes.NewValue(tftypes.String, "test-yaml"),
+				"url":                  tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: testSyntheticCheckSchema(),
 		},
@@ -210,6 +232,9 @@ func testSyntheticCheckSchema() schema.Schema {
 			},
 			"synthetic_check_yaml": schema.StringAttribute{
 				Required: true,
+			},
+			"url": schema.StringAttribute{
+				Computed: true,
 			},
 		},
 	}
@@ -339,6 +364,8 @@ func TestSyntheticCheckResource_Update(t *testing.T) {
 		client: mockClient,
 	}
 
+	testURL := "https://app.dash0.com/goto/alerting/synthetics?check_id=internal-uuid"
+
 	// Test regular update (same dataset)
 	t.Run("Update same dataset", func(t *testing.T) {
 		req := resource.UpdateRequest{
@@ -348,11 +375,13 @@ func TestSyntheticCheckResource_Update(t *testing.T) {
 						"origin":               tftypes.String,
 						"dataset":              tftypes.String,
 						"synthetic_check_yaml": tftypes.String,
+						"url":                  tftypes.String,
 					},
 				}, map[string]tftypes.Value{
 					"origin":               tftypes.NewValue(tftypes.String, "test-origin"),
 					"dataset":              tftypes.NewValue(tftypes.String, "test-dataset"),
 					"synthetic_check_yaml": tftypes.NewValue(tftypes.String, "old-yaml"),
+					"url":                  tftypes.NewValue(tftypes.String, testURL),
 				}),
 				Schema: testSyntheticCheckSchema(),
 			},
@@ -362,6 +391,7 @@ func TestSyntheticCheckResource_Update(t *testing.T) {
 						"origin":               tftypes.String,
 						"dataset":              tftypes.String,
 						"synthetic_check_yaml": tftypes.String,
+						"url":                  tftypes.String,
 					},
 				}, map[string]tftypes.Value{
 					"origin":  tftypes.NewValue(tftypes.String, "test-origin"),
@@ -370,6 +400,7 @@ func TestSyntheticCheckResource_Update(t *testing.T) {
 kind: Dash0SyntheticCheck
 metadata:
   name: updated`),
+					"url": tftypes.NewValue(tftypes.String, testURL),
 				}),
 				Schema: testSyntheticCheckSchema(),
 			},
@@ -388,5 +419,11 @@ metadata:
 
 		assert.False(t, resp.Diagnostics.HasError())
 		mockClient.AssertExpectations(t)
+
+		// URL is carried over from prior state (Update does not re-resolve it).
+		var resultState syntheticCheckModel
+		diags := resp.State.Get(ctx, &resultState)
+		require.False(t, diags.HasError(), "state cannot be unmarshalled")
+		assert.Equal(t, testURL, resultState.URL.ValueString())
 	})
 }

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
@@ -43,6 +44,7 @@ type viewModel struct {
 	Origin   types.String `tfsdk:"origin"`
 	Dataset  types.String `tfsdk:"dataset"`
 	ViewYaml types.String `tfsdk:"view_yaml"`
+	URL      types.String `tfsdk:"url"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -92,8 +94,35 @@ func (r *ViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 					customplanmodifier.YAMLSemanticEqual(converter.AnnotationSharing, converter.AnnotationFolderPath),
 				},
 			},
+			"url": schema.StringAttribute{
+				Description: "The URL to open this view in the Dash0 web app, derived from the Dash0 API URL and the view's server-assigned identifier. The page is selected based on the view's type (for example the traces explorer for span views). Computed by the provider after creation. May be empty if the app URL cannot be derived (e.g. for self-hosted deployments with a custom web app domain) or the view type has no associated page.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
+}
+
+// setViewURL resolves the view's web app URL by origin and stores it on the
+// model. The URL is best-effort metadata: failures are surfaced as warnings and
+// leave the URL null rather than failing the operation.
+func (r *ViewResource) setViewURL(ctx context.Context, model *viewModel, diags *diag.Diagnostics) {
+	viewURL, err := r.client.GetViewURL(ctx, model.Origin.ValueString(), model.Dataset.ValueString())
+	if err != nil {
+		diags.AddWarning(
+			"Unable to determine view URL",
+			fmt.Sprintf("The view was saved successfully, but its URL could not be determined: %s", err),
+		)
+		model.URL = types.StringNull()
+		return
+	}
+	if viewURL == "" {
+		model.URL = types.StringNull()
+		return
+	}
+	model.URL = types.StringValue(viewURL)
 }
 
 func (r *ViewResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -129,6 +158,9 @@ func (r *ViewResource) Create(ctx context.Context, req resource.CreateRequest, r
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create view, got error: %s", err))
 		return
 	}
+
+	// Resolve the web app URL for the newly created view (best-effort).
+	r.setViewURL(ctx, &model, &resp.Diagnostics)
 
 	tflog.Trace(ctx, "created a view resource")
 
@@ -217,6 +249,9 @@ func (r *ViewResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// Update the existing view (dataset changes force recreation via RequiresReplace)
 	plan.Origin = state.Origin
+	// The view's identifier is immutable, so the URL never changes on update;
+	// carry it from state instead of re-resolving it via the API.
+	plan.URL = state.URL
 	err = r.client.UpdateView(ctx, plan.Origin.ValueString(), jsonBody, plan.Dataset.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update view, got error: %s", err))
@@ -273,4 +308,9 @@ func (r *ViewResource) ImportState(ctx context.Context, req resource.ImportState
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("origin"), origin)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("dataset"), dataset)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("view_yaml"), apiResponseJSON)...)
+
+	// Resolve the web app URL (best-effort).
+	model := viewModel{Origin: types.StringValue(origin), Dataset: types.StringValue(dataset)}
+	r.setViewURL(ctx, &model, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("url"), model.URL)...)
 }

--- a/internal/provider/view_resource_acc_test.go
+++ b/internal/provider/view_resource_acc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -193,6 +194,9 @@ func TestAccViewResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr(viewResourceName, "dataset", "terraform-test"),
 					resource.TestCheckResourceAttrSet(viewResourceName, "origin"),
+					// Verify the computed URL is set and points at the web app deep link
+					resource.TestMatchResourceAttr(viewResourceName, "url",
+						regexp.MustCompile(`^https://app\..+/goto/.+`)),
 				),
 			},
 			// ImportState testing
@@ -221,6 +225,12 @@ func TestAccViewResource(t *testing.T) {
 					// Verify the view_yaml attribute
 					if yaml := states[0].Attributes["view_yaml"]; yaml == "" {
 						return fmt.Errorf("view_yaml attribute is missing or empty")
+					}
+
+					// Verify the computed url is resolved on import
+					urlPattern := regexp.MustCompile(`^https://app\..+/goto/.+`)
+					if u := states[0].Attributes["url"]; !urlPattern.MatchString(u) {
+						return fmt.Errorf("url attribute %q does not match expected view deep link pattern", u)
 					}
 
 					return nil

--- a/internal/provider/view_resource_read_test.go
+++ b/internal/provider/view_resource_read_test.go
@@ -104,6 +104,9 @@ spec:
 					"view_yaml": schema.StringAttribute{
 						Required: true,
 					},
+					"url": schema.StringAttribute{
+						Computed: true,
+					},
 				},
 			}
 
@@ -115,6 +118,8 @@ spec:
 			// Create the resource with the test client
 			r := &ViewResource{client: testClient}
 
+			testURL := "https://app.dash0.com/goto/traces/explorer?view_id=internal-uuid"
+
 			// Create the state object
 			raw := tftypes.NewValue(
 				tftypes.Object{
@@ -122,12 +127,14 @@ spec:
 						"origin":    tftypes.String,
 						"dataset":   tftypes.String,
 						"view_yaml": tftypes.String,
+						"url":       tftypes.String,
 					},
 				},
 				map[string]tftypes.Value{
 					"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 					"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 					"view_yaml": tftypes.NewValue(tftypes.String, originalYaml),
+					"url":       tftypes.NewValue(tftypes.String, testURL),
 				},
 			)
 
@@ -161,6 +168,9 @@ spec:
 			} else {
 				assert.Equal(t, originalYaml, resultState.ViewYaml.ValueString())
 			}
+
+			// URL is carried over from prior state (Read does not re-resolve it).
+			assert.Equal(t, testURL, resultState.URL.ValueString())
 
 			// Check for warnings
 			hasWarnings := resp.Diagnostics.WarningsCount() > 0

--- a/internal/provider/view_resource_test.go
+++ b/internal/provider/view_resource_test.go
@@ -39,11 +39,13 @@ func TestViewResource_Schema(t *testing.T) {
 	assert.Contains(t, resp.Schema.Attributes, "origin")
 	assert.Contains(t, resp.Schema.Attributes, "dataset")
 	assert.Contains(t, resp.Schema.Attributes, "view_yaml")
+	assert.Contains(t, resp.Schema.Attributes, "url")
 
 	// Check specific attribute properties
 	assert.True(t, resp.Schema.Attributes["origin"].(schema.StringAttribute).Computed)
 	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Required)
 	assert.True(t, resp.Schema.Attributes["view_yaml"].(schema.StringAttribute).Required)
+	assert.True(t, resp.Schema.Attributes["url"].(schema.StringAttribute).Computed)
 }
 
 func TestViewResource_Configure(t *testing.T) {
@@ -75,6 +77,7 @@ func TestViewResource_Create(t *testing.T) {
 	// Setup test data
 	testYaml := "kind: View\nmetadata:\n  name: example-view\nspec:\n  title: Example View"
 	testDataset := "test-dataset"
+	testURL := "https://app.dash0.com/goto/traces/explorer?view_id=internal-uuid"
 
 	// Setup plan
 	plan := tfsdk.Plan{
@@ -82,6 +85,7 @@ func TestViewResource_Create(t *testing.T) {
 			"origin":    tftypes.NewValue(tftypes.String, ""),
 			"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 			"view_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":       tftypes.NewValue(tftypes.String, nil),
 		}),
 		Schema: schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -93,6 +97,9 @@ func TestViewResource_Create(t *testing.T) {
 				},
 				"view_yaml": schema.StringAttribute{
 					Required: true,
+				},
+				"url": schema.StringAttribute{
+					Computed: true,
 				},
 			},
 		},
@@ -113,6 +120,8 @@ func TestViewResource_Create(t *testing.T) {
 
 	// Setup mock expectations - CreateView(ctx, origin, jsonBody, dataset)
 	mockClient.On("CreateView", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	// After create, the URL is resolved by origin (generated tf_-prefixed value).
+	mockClient.On("GetViewURL", mock.Anything, mock.Anything, testDataset).Return(testURL, nil)
 
 	// Execute the create operation
 	r.Create(context.Background(), req, &resp)
@@ -120,6 +129,12 @@ func TestViewResource_Create(t *testing.T) {
 	// Verify expectations
 	mockClient.AssertExpectations(t)
 	assert.False(t, resp.Diagnostics.HasError())
+
+	// Verify the resolved URL was written to state
+	var resultState viewModel
+	diags := resp.State.Get(context.Background(), &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 }
 
 func TestViewResource_Read(t *testing.T) {
@@ -130,6 +145,8 @@ func TestViewResource_Read(t *testing.T) {
 	testOrigin := "test-origin"
 	testDataset := "test-dataset"
 	testYaml := "kind: View\nmetadata:\n  name: example-view\nspec:\n  title: Example View"
+
+	testURL := "https://app.dash0.com/goto/traces/explorer?view_id=internal-uuid"
 
 	// Create state schema
 	stateSchema := schema.Schema{
@@ -143,6 +160,9 @@ func TestViewResource_Read(t *testing.T) {
 			"view_yaml": schema.StringAttribute{
 				Required: true,
 			},
+			"url": schema.StringAttribute{
+				Computed: true,
+			},
 		},
 	}
 
@@ -152,6 +172,7 @@ func TestViewResource_Read(t *testing.T) {
 			"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 			"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 			"view_yaml": tftypes.NewValue(tftypes.String, "old yaml"),
+			"url":       tftypes.NewValue(tftypes.String, testURL),
 		}),
 		Schema: stateSchema,
 	}
@@ -185,6 +206,8 @@ func TestViewResource_Read(t *testing.T) {
 	assert.Equal(t, testOrigin, resultState.Origin.ValueString())
 	assert.Equal(t, testDataset, resultState.Dataset.ValueString())
 	assert.Equal(t, testYaml, resultState.ViewYaml.ValueString())
+	// URL is carried over from prior state (Read does not re-resolve it).
+	assert.Equal(t, testURL, resultState.URL.ValueString())
 
 	// Test with API error
 	mockClient = new(MockClient)
@@ -396,6 +419,8 @@ func TestViewResource_Update(t *testing.T) {
 	testYaml := "kind: View\nmetadata:\n  name: example-view\nspec:\n  title: Example View"
 	_ = testYaml
 
+	testURL := "https://app.dash0.com/goto/traces/explorer?view_id=internal-uuid"
+
 	// Test 1: Update view YAML only (no dataset change)
 	t.Run("update yaml only", func(t *testing.T) {
 		mockClient := new(MockClient)
@@ -407,6 +432,7 @@ func TestViewResource_Update(t *testing.T) {
 				"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 				"view_yaml": tftypes.NewValue(tftypes.String, testYaml),
+				"url":       tftypes.NewValue(tftypes.String, testURL),
 			}),
 			Schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -418,6 +444,9 @@ func TestViewResource_Update(t *testing.T) {
 					},
 					"view_yaml": schema.StringAttribute{
 						Required: true,
+					},
+					"url": schema.StringAttribute{
+						Computed: true,
 					},
 				},
 			},
@@ -431,6 +460,7 @@ func TestViewResource_Update(t *testing.T) {
 				"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 				"view_yaml": tftypes.NewValue(tftypes.String, updatedYaml),
+				"url":       tftypes.NewValue(tftypes.String, testURL),
 			}),
 			Schema: state.Schema,
 		}
@@ -453,6 +483,12 @@ func TestViewResource_Update(t *testing.T) {
 		// Verify expectations
 		mockClient.AssertExpectations(t)
 		assert.False(t, resp.Diagnostics.HasError())
+
+		// URL is carried over from prior state (Update does not re-resolve it).
+		var resultState viewModel
+		diags := resp.State.Get(context.Background(), &resultState)
+		require.False(t, diags.HasError(), "state cannot be unmarshalled")
+		assert.Equal(t, testURL, resultState.URL.ValueString())
 	})
 
 	// Test 2: Invalid YAML
@@ -468,6 +504,7 @@ func TestViewResource_Update(t *testing.T) {
 				"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 				"view_yaml": tftypes.NewValue(tftypes.String, testYaml),
+				"url":       tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -480,6 +517,9 @@ func TestViewResource_Update(t *testing.T) {
 					"view_yaml": schema.StringAttribute{
 						Required: true,
 					},
+					"url": schema.StringAttribute{
+						Computed: true,
+					},
 				},
 			},
 		}
@@ -490,6 +530,7 @@ func TestViewResource_Update(t *testing.T) {
 				"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 				"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 				"view_yaml": tftypes.NewValue(tftypes.String, "invalid: yaml: : :"),
+				"url":       tftypes.NewValue(tftypes.String, nil),
 			}),
 			Schema: state.Schema,
 		}
@@ -526,6 +567,7 @@ func TestViewResource_Delete(t *testing.T) {
 			"origin":    tftypes.NewValue(tftypes.String, testOrigin),
 			"dataset":   tftypes.NewValue(tftypes.String, testDataset),
 			"view_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":       tftypes.NewValue(tftypes.String, "https://app.dash0.com/goto/traces/explorer?view_id=internal-uuid"),
 		}),
 		Schema: schema.Schema{
 			Attributes: map[string]schema.Attribute{
@@ -537,6 +579,9 @@ func TestViewResource_Delete(t *testing.T) {
 				},
 				"view_yaml": schema.StringAttribute{
 					Required: true,
+				},
+				"url": schema.StringAttribute{
+					Computed: true,
 				},
 			},
 		},

--- a/test/roundtrip/test_check_rule.sh
+++ b/test/roundtrip/test_check_rule.sh
@@ -65,6 +65,10 @@ variable "dataset" {
 output "origin" {
   value = dash0_check_rule.test.origin
 }
+
+output "url" {
+  value = dash0_check_rule.test.url
+}
 EOF
 
 tf_init "$WORK_DIR"
@@ -72,6 +76,13 @@ TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR"
 
 ORIGIN="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" origin)"
 info "Created check rule with origin: ${ORIGIN}"
+
+# Verify the computed url attribute is a Dash0 web app deep link.
+URL="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" url)"
+info "Check rule url: ${URL}"
+echo "$URL" | grep -Eq '^https://app\..+/goto/.+' \
+  || fail "check rule url output '${URL}' is not a valid deep link"
+info "Check rule url check PASSED."
 
 # ---------------------------------------------------------------------------
 # Step 2: Verify via dash0 CLI

--- a/test/roundtrip/test_dashboard.sh
+++ b/test/roundtrip/test_dashboard.sh
@@ -77,6 +77,10 @@ variable "dataset" {
 output "origin" {
   value = dash0_dashboard.test.origin
 }
+
+output "url" {
+  value = dash0_dashboard.test.url
+}
 EOF
 
 tf_init "$WORK_DIR"
@@ -84,6 +88,13 @@ TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR"
 
 ORIGIN="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" origin)"
 info "Created dashboard with origin: ${ORIGIN}"
+
+# Verify the computed url attribute is a Dash0 dashboard deep link.
+URL="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" url)"
+info "Dashboard url: ${URL}"
+echo "$URL" | grep -Eq '^https://app\..+/goto/dashboards\?dashboard_id=.+' \
+  || fail "dashboard url output '${URL}' is not a valid dashboard deep link"
+info "Dashboard url check PASSED."
 
 # ---------------------------------------------------------------------------
 # Step 2: Verify via dash0 CLI

--- a/test/roundtrip/test_synthetic_check.sh
+++ b/test/roundtrip/test_synthetic_check.sh
@@ -77,6 +77,10 @@ variable "dataset" {
 output "origin" {
   value = dash0_synthetic_check.test.origin
 }
+
+output "url" {
+  value = dash0_synthetic_check.test.url
+}
 EOF
 
 tf_init "$WORK_DIR"
@@ -84,6 +88,13 @@ TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR"
 
 ORIGIN="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" origin)"
 info "Created synthetic check with origin: ${ORIGIN}"
+
+# Verify the computed url attribute is a Dash0 web app deep link.
+URL="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" url)"
+info "Synthetic check url: ${URL}"
+echo "$URL" | grep -Eq '^https://app\..+/goto/.+' \
+  || fail "synthetic check url output '${URL}' is not a valid deep link"
+info "Synthetic check url check PASSED."
 
 # ---------------------------------------------------------------------------
 # Step 2: Verify via dash0 CLI

--- a/test/roundtrip/test_view.sh
+++ b/test/roundtrip/test_view.sh
@@ -73,6 +73,10 @@ variable "dataset" {
 output "origin" {
   value = dash0_view.test.origin
 }
+
+output "url" {
+  value = dash0_view.test.url
+}
 EOF
 
 tf_init "$WORK_DIR"
@@ -80,6 +84,13 @@ TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR"
 
 ORIGIN="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" origin)"
 info "Created view with origin: ${ORIGIN}"
+
+# Verify the computed url attribute is a Dash0 web app deep link.
+URL="$(TF_VAR_dataset="$DATASET" tf_output "$WORK_DIR" url)"
+info "View url: ${URL}"
+echo "$URL" | grep -Eq '^https://app\..+/goto/.+' \
+  || fail "view url output '${URL}' is not a valid deep link"
+info "View url check PASSED."
 
 # ---------------------------------------------------------------------------
 # Step 2: Verify via dash0 CLI


### PR DESCRIPTION
## What

Adds a computed, read-only `url` attribute to the four deep-link-capable resources — `dash0_dashboard`, `dash0_check_rule`, `dash0_synthetic_check`, and `dash0_view` — linking directly to each resource in the Dash0 web app.

```hcl
output "dashboard_url" {
  value = dash0_dashboard.my_dashboard.url
}
```

## How

- Bumps `dash0-api-client-go` to **v1.13.0** and builds URLs with its shared deep-link builders (`dash0.DeeplinkURL` / `dash0.ViewDeeplinkURL`) — the logic that previously lived in the provider and the CLI now has a single home in the API client library.
- The web app addresses resources by their server-assigned internal id (distinct from the provider's `tf_` origin), so the id is resolved from each resource's list endpoint by matching on `origin` (a shared generic `matchOriginID` helper). Views select the correct page from their type.
- The `url` is resolved on **create** and **import** and carried in state on **read/update** (the id is immutable). Best-effort: if the app host can't be derived (e.g. a self-hosted custom domain), the attribute is left empty rather than failing.

## Tests

- Unit tests for all four resources (schema, create resolves url, read/update carry it).
- Acceptance tests assert the `url` format on create and import.
- Roundtrip scripts assert a valid deep link for each resource.
- Docs regenerated; changelog entry covers all four resources.

Depends on `dash0hq/dash0-api-client-go` v1.13.0 (merged & released). Companion CLI refactor: see the dash0-cli PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
