### PR TITLE
chore(docs): clarify dataset identifier

### DIFF
--- a/docs/resources/check_rule.md
+++ b/docs/resources/check_rule.md
@@ -51,7 +51,7 @@ EOF
 ### Required
 
 - `check_rule_yaml` (String) The check rule definition in YAML format, following the [Prometheus alerting rule specification](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/). The `dash0.com/sharing` metadata annotation is supported to control sharing settings; changes to it trigger a resource update. All other metadata annotations are managed by the server and ignored during drift detection.
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/check_rule.md
+++ b/docs/resources/check_rule.md
@@ -51,7 +51,7 @@ EOF
 ### Required
 
 - `check_rule_yaml` (String) The check rule definition in YAML format, following the [Prometheus alerting rule specification](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/). The `dash0.com/sharing` metadata annotation is supported to control sharing settings; changes to it trigger a resource update. All other metadata annotations are managed by the server and ignored during drift detection.
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -25,7 +25,7 @@ resource "dash0_dashboard" "my_dashboard" {
 ### Required
 
 - `dashboard_yaml` (String) The dashboard definition in YAML format, following the [Perses Dashboard specification](https://dash0.com/docs/dash0/dashboards/reference-dashboard-source-format). The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -25,7 +25,7 @@ resource "dash0_dashboard" "my_dashboard" {
 ### Required
 
 - `dashboard_yaml` (String) The dashboard definition in YAML format, following the [Perses Dashboard specification](https://dash0.com/docs/dash0/dashboards/reference-dashboard-source-format). The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/recording_rule.md
+++ b/docs/resources/recording_rule.md
@@ -39,7 +39,7 @@ EOF
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `recording_rule_yaml` (String) The recording rule definition in YAML format, following the [Prometheus recording rule specification](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
 
 ### Read-Only

--- a/docs/resources/recording_rule.md
+++ b/docs/resources/recording_rule.md
@@ -39,7 +39,7 @@ EOF
 
 ### Required
 
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `recording_rule_yaml` (String) The recording rule definition in YAML format, following the [Prometheus recording rule specification](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
 
 ### Read-Only

--- a/docs/resources/spam_filter.md
+++ b/docs/resources/spam_filter.md
@@ -57,7 +57,7 @@ EOF
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `spam_filter_yaml` (String) The spam filter definition in YAML format. The YAML must include a `metadata.name` field and a `spec` with a `filter` (list of key-value matchers) and either `contexts` (`v1alpha1`, a list of signal types: `log`, `span`, `datapoint` or `web_event`) or `context` (`v1alpha2`, a single signal type out of `log`, `span`, `datapoint` and `web_event`). The `apiVersion` field determines which shape is expected.
 
 ### Read-Only

--- a/docs/resources/spam_filter.md
+++ b/docs/resources/spam_filter.md
@@ -57,7 +57,7 @@ EOF
 
 ### Required
 
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `spam_filter_yaml` (String) The spam filter definition in YAML format. The YAML must include a `metadata.name` field and a `spec` with a `filter` (list of key-value matchers) and either `contexts` (`v1alpha1`, a list of signal types: `log`, `span`, `datapoint` or `web_event`) or `context` (`v1alpha2`, a single signal type out of `log`, `span`, `datapoint` and `web_event`). The `apiVersion` field determines which shape is expected.
 
 ### Read-Only

--- a/docs/resources/synthetic_check.md
+++ b/docs/resources/synthetic_check.md
@@ -24,7 +24,7 @@ resource "dash0_synthetic_check" "my_check" {
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `synthetic_check_yaml` (String) The synthetic check definition in YAML format, specifying the check type, target URL, schedule, and assertion criteria. See [Create Synthetic Checks](https://dash0.com/docs/dash0/monitoring/synthetics/create-synthetic-checks) for the available options. The `dash0.com/sharing` metadata annotation is supported to control sharing settings; changes to it trigger a resource update. All other metadata annotations are managed by the server and ignored during drift detection.
 
 ### Read-Only

--- a/docs/resources/synthetic_check.md
+++ b/docs/resources/synthetic_check.md
@@ -24,7 +24,7 @@ resource "dash0_synthetic_check" "my_check" {
 
 ### Required
 
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `synthetic_check_yaml` (String) The synthetic check definition in YAML format, specifying the check type, target URL, schedule, and assertion criteria. See [Create Synthetic Checks](https://dash0.com/docs/dash0/monitoring/synthetics/create-synthetic-checks) for the available options. The `dash0.com/sharing` metadata annotation is supported to control sharing settings; changes to it trigger a resource update. All other metadata annotations are managed by the server and ignored during drift detection.
 
 ### Read-Only

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -24,7 +24,7 @@ resource "dash0_view" "my_check" {
 
 ### Required
 
-- `dataset` (String) The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `view_yaml` (String) The view definition in YAML format, specifying the filters, queries, and display settings for the view. The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
 
 ### Read-Only

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -24,7 +24,7 @@ resource "dash0_view" "my_check" {
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's unique identifier (e.g. "default" or "production"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `view_yaml` (String) The view definition in YAML format, specifying the filters, queries, and display settings for the view. The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
 
 ### Read-Only

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -82,7 +82,7 @@ More information on how Prometheus rules are mapped to Dash0 check rules can be 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -82,7 +82,7 @@ More information on how Prometheus rules are mapped to Dash0 check rules can be 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -79,7 +79,7 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -79,7 +79,7 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/recording_rule_resource.go
+++ b/internal/provider/recording_rule_resource.go
@@ -82,7 +82,7 @@ More information on how Prometheus rules are mapped to Dash0 recording rules can
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/recording_rule_resource.go
+++ b/internal/provider/recording_rule_resource.go
@@ -82,7 +82,7 @@ More information on how Prometheus rules are mapped to Dash0 recording rules can
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/spam_filter_resource.go
+++ b/internal/provider/spam_filter_resource.go
@@ -83,7 +83,7 @@ func (r *SpamFilterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/spam_filter_resource.go
+++ b/internal/provider/spam_filter_resource.go
@@ -83,7 +83,7 @@ func (r *SpamFilterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -79,7 +79,7 @@ func (r *SyntheticCheckResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -79,7 +79,7 @@ func (r *SyntheticCheckResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -79,7 +79,7 @@ func (r *ViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -79,7 +79,7 @@ func (r *ViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's unique identifier (e.g. \"default\" or \"production\"), not its display name. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
## Summary

The dataset attribute description across all resource types was ambiguous — it wasn't clear that the field expects a dataset identifier or name. This could lead users to provide the wrong value and get confusing errors.

This PR updates the dataset attribute description for all six resource types (dashboard, check rule, recording rule, synthetic check, spam filter, view) to explicitly state that the identifier is required, not the display name, and adds a concrete example.

## Changes
- Clarified dataset attribute description in all resource schemas (*.go) and regenerated docs (docs/resources/*.md)
- No behavior changes — documentation/schema description only