### PR TITLE
fix(notification_channels): ignore server-written spec.routing.assets

### DIFF
--- a/.chloggen/notification-channel-routing-assets.yaml
+++ b/.chloggen/notification-channel-routing-assets.yaml
@@ -1,0 +1,39 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: notification_channels
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Resolve perpetual drift on dash0_notification_channel when a check rule or synthetic check binds to the channel by id.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues:
+  - 128
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Dash0 API populates `spec.routing.assets` on a notification channel as a
+  back-reference whenever a check rule (via the
+  `dash0.com/notification-channel-ids` annotation) or a synthetic check (via
+  `spec.notifications.channels`) binds to the channel by id. The field is
+  discarded on write, so previous releases produced a perpetual diff that
+  attempted to wipe the back-reference on every plan. The provider now treats
+  `spec.routing.assets` as API-managed and ignores it during comparison.
+
+  If a user supplies `spec.routing.assets` on the channel YAML, the provider
+  emits a warning on create and update, since the Dash0 API will discard the
+  value. Bind a check rule or synthetic check to a channel from the check
+  resource instead.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/docs/resources/notification_channel.md
+++ b/docs/resources/notification_channel.md
@@ -204,7 +204,7 @@ YAML
 
 ### Required
 
-- `notification_channel_yaml` (String) The notification channel definition in YAML format. The YAML must include `kind: Dash0NotificationChannel`, a `metadata.name` field, and a `spec` with `type` and type-specific `config`. Optional fields include `frequency` (default `10m`) and `routing` for filtering which alerts are delivered. See [Send Alert Check Notifications](https://www.dash0.com/docs/dash0/monitoring/alerting/send-alert-check-notifications) for the available options.
+- `notification_channel_yaml` (String) The notification channel definition in YAML format. The YAML must include `kind: Dash0NotificationChannel`, a `metadata.name` field, and a `spec` with `type` and type-specific `config`. Optional fields include `frequency` (default `10m`) and `routing` for filtering which alerts are delivered. Note that `spec.routing.assets` is populated by the Dash0 API as a back-reference when a check rule or synthetic check binds to this channel by id, and is discarded if supplied on write; bind a check rule by setting the `dash0.com/notification-channel-ids` annotation on the rule, or a synthetic check by setting `spec.notifications.channels` on the synthetic check. See [Send Alert Check Notifications](https://www.dash0.com/docs/dash0/monitoring/alerting/send-alert-check-notifications) for the available options.
 
 ### Read-Only
 

--- a/internal/provider/notification_channel_resource.go
+++ b/internal/provider/notification_channel_resource.go
@@ -30,11 +30,56 @@ var notificationChannelConditionallyIgnoredFields = append(
 	"spec.routing",   // server default (empty assets/filters)
 )
 
+// notificationChannelAlwaysIgnoredFields are fields the API maintains on the
+// channel even when the user includes other siblings in routing. The Dash0
+// API discards spec.routing.assets on write and instead populates it as a
+// back-reference whenever a check rule or synthetic check binds itself to the
+// channel by id. Comparing the field during drift detection would therefore
+// produce a perpetual diff whenever any check rule or synthetic check is
+// bound to the channel.
+var notificationChannelAlwaysIgnoredFields = []string{
+	"spec.routing.assets",
+}
+
+// warnIfRoutingAssetsSet emits a Warning when the user's YAML declares a
+// non-empty spec.routing.assets list. The Dash0 API discards this field on
+// write, so the value will not take effect; binding a check rule or synthetic
+// check to a notification channel must be expressed on the check resource.
+func warnIfRoutingAssetsSet(channelYaml string, diags *diag.Diagnostics) {
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal([]byte(channelYaml), &parsed); err != nil {
+		return
+	}
+	spec, ok := parsed["spec"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	routing, ok := spec["routing"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	assets, ok := routing["assets"].([]interface{})
+	if !ok || len(assets) == 0 {
+		return
+	}
+	diags.AddWarning(
+		"spec.routing.assets is API-managed and ignored on write",
+		"The Dash0 API populates spec.routing.assets as a back-reference when "+
+			"other resources bind to this notification channel by id, and "+
+			"discards any value supplied on write. The entries you provided "+
+			"will not take effect. To bind a check rule, set the annotation "+
+			"dash0.com/notification-channel-ids on the check rule; to bind a "+
+			"synthetic check, set spec.notifications.channels on the "+
+			"synthetic check.",
+	)
+}
+
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &NotificationChannelResource{}
-	_ resource.ResourceWithConfigure   = &NotificationChannelResource{}
-	_ resource.ResourceWithImportState = &NotificationChannelResource{}
+	_ resource.Resource                   = &NotificationChannelResource{}
+	_ resource.ResourceWithConfigure      = &NotificationChannelResource{}
+	_ resource.ResourceWithImportState    = &NotificationChannelResource{}
+	_ resource.ResourceWithValidateConfig = &NotificationChannelResource{}
 )
 
 // NewNotificationChannelResource is a helper function to simplify the provider implementation.
@@ -77,6 +122,22 @@ func (r *NotificationChannelResource) Metadata(_ context.Context, req resource.M
 	resp.TypeName = req.ProviderTypeName + "_notification_channel"
 }
 
+// ValidateConfig surfaces warnings about config that the Dash0 API will not
+// honor. Currently this is limited to spec.routing.assets, which is discarded
+// on write and reflects only server-maintained back-references on read.
+func (r *NotificationChannelResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var model notificationChannelModel
+	diags := req.Config.Get(ctx, &model)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if model.NotificationChannelYaml.IsNull() || model.NotificationChannelYaml.IsUnknown() {
+		return
+	}
+	warnIfRoutingAssetsSet(model.NotificationChannelYaml.ValueString(), &resp.Diagnostics)
+}
+
 func (r *NotificationChannelResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Manages a Dash0 Notification Channel. Notification channels define how alerts are delivered to " +
@@ -108,10 +169,14 @@ func (r *NotificationChannelResource) Schema(_ context.Context, _ resource.Schem
 					"The YAML must include `kind: Dash0NotificationChannel`, a `metadata.name` field, " +
 					"and a `spec` with `type` and type-specific `config`. " +
 					"Optional fields include `frequency` (default `10m`) and `routing` for filtering which alerts are delivered. " +
+					"Note that `spec.routing.assets` is populated by the Dash0 API as a back-reference when a check rule or " +
+					"synthetic check binds to this channel by id, and is discarded if supplied on write; bind a check rule by " +
+					"setting the `dash0.com/notification-channel-ids` annotation on the rule, or a synthetic check by setting " +
+					"`spec.notifications.channels` on the synthetic check. " +
 					"See [Send Alert Check Notifications](https://www.dash0.com/docs/dash0/monitoring/alerting/send-alert-check-notifications) for the available options.",
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					customplanmodifier.YAMLSemanticEqual(),
+					customplanmodifier.YAMLSemanticEqualWith(notificationChannelAlwaysIgnoredFields),
 				},
 			},
 			"url": schema.StringAttribute{
@@ -209,6 +274,7 @@ func (r *NotificationChannelResource) Read(ctx context.Context, req resource.Rea
 	if state.NotificationChannelYaml.ValueString() != "" {
 		stateYAML := state.NotificationChannelYaml.ValueString()
 		additionalIgnored := converter.FieldsAbsentFromYAML(stateYAML, notificationChannelConditionallyIgnoredFields)
+		additionalIgnored = append(additionalIgnored, notificationChannelAlwaysIgnoredFields...)
 		equivalent, err := converter.ResourceYAMLEquivalent(stateYAML, apiResponseJSON, additionalIgnored, nil)
 		if err != nil {
 			resp.Diagnostics.AddWarning(

--- a/internal/provider/notification_channel_resource_read_test.go
+++ b/internal/provider/notification_channel_resource_read_test.go
@@ -173,3 +173,95 @@ spec:
 		})
 	}
 }
+
+// Regression for https://github.com/dash0hq/terraform-provider-dash0/issues/128.
+// The user's state declares spec.routing.filters (so the conditional ignore on
+// spec.routing does not fire) along with an empty spec.routing.assets list.
+// A bound synthetic check (or check rule) then causes the server to populate
+// spec.routing.assets on retrieval. Read must treat this as no drift so plans
+// do not flap and reapplying does not strip the server-written entry.
+func TestNotificationChannelResource_ReadIgnoresServerWrittenRoutingAssets(t *testing.T) {
+	testOrigin := "test-notification-channel"
+
+	stateYaml := `
+kind: Dash0NotificationChannel
+metadata:
+  name: team-platform-critical
+spec:
+  type: slack_bot
+  frequency: 6h0m0s
+  config:
+    teamId: "T012345"
+    channel: "#alerts-platform-critical"
+  routing:
+    assets: []
+    filters:
+      - - key: team
+          operator: is
+          value: platform
+`
+
+	apiResponseYaml := `
+kind: Dash0NotificationChannel
+metadata:
+  name: team-platform-critical
+spec:
+  type: slack_bot
+  frequency: 6h0m0s
+  config:
+    teamId: "T012345"
+    channel: "#alerts-platform-critical"
+  routing:
+    assets:
+      - kind: synthetic_check
+        id: "11111111-2222-3333-4444-555555555555"
+        name: "auto-attached check"
+        dataset: "default"
+    filters:
+      - - key: team
+          operator: is
+          value: platform
+`
+
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"origin":                    schema.StringAttribute{Computed: true},
+			"id":                        schema.StringAttribute{Computed: true},
+			"notification_channel_yaml": schema.StringAttribute{Required: true},
+			"url":                       schema.StringAttribute{Computed: true},
+		},
+	}
+
+	testClient := &testNotificationChannelClient{getResponse: apiResponseYaml}
+	r := &NotificationChannelResource{client: testClient}
+
+	raw := tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"origin":                    tftypes.String,
+				"id":                        tftypes.String,
+				"notification_channel_yaml": tftypes.String,
+				"url":                       tftypes.String,
+			},
+		},
+		map[string]tftypes.Value{
+			"origin":                    tftypes.NewValue(tftypes.String, testOrigin),
+			"id":                        tftypes.NewValue(tftypes.String, nil),
+			"notification_channel_yaml": tftypes.NewValue(tftypes.String, stateYaml),
+			"url":                       tftypes.NewValue(tftypes.String, nil),
+		},
+	)
+
+	state := tfsdk.State{Raw: raw, Schema: testSchema}
+	req := resource.ReadRequest{State: state}
+	resp := resource.ReadResponse{State: state}
+
+	r.Read(context.Background(), req, &resp)
+
+	var resultState notificationChannelModel
+	resp.State.Get(context.Background(), &resultState)
+
+	assert.Equal(t, stateYaml, resultState.NotificationChannelYaml.ValueString(),
+		"server-written spec.routing.assets must not trigger a state update")
+	assert.Equal(t, 0, resp.Diagnostics.WarningsCount())
+}

--- a/internal/provider/notification_channel_resource_test.go
+++ b/internal/provider/notification_channel_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -231,4 +232,75 @@ func TestNotificationChannelResource_ReadError(t *testing.T) {
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Client Error")
 
 	mockClient.AssertExpectations(t)
+}
+
+func TestWarnIfRoutingAssetsSet(t *testing.T) {
+	cases := []struct {
+		name       string
+		yaml       string
+		expectWarn bool
+	}{
+		{
+			name: "no routing",
+			yaml: `
+kind: Dash0NotificationChannel
+spec:
+  type: webhook
+`,
+			expectWarn: false,
+		},
+		{
+			name: "routing without assets",
+			yaml: `
+kind: Dash0NotificationChannel
+spec:
+  type: webhook
+  routing:
+    filters:
+      - - key: team
+          operator: is
+          value: platform
+`,
+			expectWarn: false,
+		},
+		{
+			name: "empty assets list",
+			yaml: `
+kind: Dash0NotificationChannel
+spec:
+  type: webhook
+  routing:
+    assets: []
+`,
+			expectWarn: false,
+		},
+		{
+			name: "non-empty assets list",
+			yaml: `
+kind: Dash0NotificationChannel
+spec:
+  type: webhook
+  routing:
+    assets:
+      - kind: check_rule
+        id: "00000000-0000-0000-0000-000000000000"
+        name: "rule"
+        dataset: "default"
+`,
+			expectWarn: true,
+		},
+		{
+			name:       "invalid yaml is silently ignored (validated elsewhere)",
+			yaml:       "not valid {",
+			expectWarn: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var diags diag.Diagnostics
+			warnIfRoutingAssetsSet(tc.yaml, &diags)
+			assert.Equal(t, tc.expectWarn, diags.WarningsCount() > 0)
+		})
+	}
 }

--- a/internal/provider/planmodifier/yaml_semantic_equal.go
+++ b/internal/provider/planmodifier/yaml_semantic_equal.go
@@ -21,8 +21,21 @@ func YAMLSemanticEqual(preservedAnnotationKeys ...string) planmodifier.String {
 	}
 }
 
+// YAMLSemanticEqualWith returns a plan modifier like YAMLSemanticEqual, but
+// also strips alwaysIgnoredFields from both YAMLs before comparison. Use this
+// when a resource has fields that are fully API-managed (e.g. back-references
+// populated by other resources) so the user's config and the API response
+// stay equivalent regardless of what the server writes there.
+func YAMLSemanticEqualWith(alwaysIgnoredFields []string, preservedAnnotationKeys ...string) planmodifier.String {
+	return yamlSemanticEqualModifier{
+		preservedAnnotationKeys: preservedAnnotationKeys,
+		alwaysIgnoredFields:     alwaysIgnoredFields,
+	}
+}
+
 type yamlSemanticEqualModifier struct {
 	preservedAnnotationKeys []string
+	alwaysIgnoredFields     []string
 }
 
 func (m yamlSemanticEqualModifier) Description(_ context.Context) string {
@@ -51,6 +64,7 @@ func (m yamlSemanticEqualModifier) PlanModifyString(_ context.Context, req planm
 	// Conditionally ignore API-managed fields that the user didn't include in their config.
 	// e.g., spec.permissions is enriched by the API on retrieval but users may optionally manage it.
 	additionalIgnored := converter.FieldsAbsentFromYAML(configYAML, converter.ConditionallyIgnoredFields)
+	additionalIgnored = append(additionalIgnored, m.alwaysIgnoredFields...)
 	equivalent, err := converter.ResourceYAMLEquivalent(configYAML, stateYAML, additionalIgnored, m.preservedAnnotationKeys)
 	if err != nil {
 		// On error, let Terraform use normal comparison


### PR DESCRIPTION
The Dash0 API materializes spec.routing.assets on a notification channel as a back-reference when a check rule (via dash0.com/notification-channel-ids) or a synthetic check (via spec.notifications.channels) binds to the channel by id. The field is discarded on write, so prior releases produced a perpetual diff that attempted to wipe the back-reference on every plan.

This change strips `spec.routing.assets` from drift comparison on both the plan modifier and read paths. Also adds a `ValidateConfig` diagnostic that warns when a user declares non-empty `spec.routing.assets` on the channel resource, since the value will not take effect.

Closes #128 