### PR TITLE
chore: add changelog entry for v1.14.2 (AWS CloudFormation docs)

### DIFF
--- a/.chloggen/aws-cloudformation-integration-docs.yaml
+++ b/.chloggen/aws-cloudformation-integration-docs.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+component: provider
+note: Add AWS CloudFormation integration guide and Terraform example for IaC onboarding.
+issues:
+  - 76
+subtext: |
+  Documents deploying the Dash0 AWS integration via the AWS provider's
+  `aws_cloudformation_stack` resource and the hosted v2 CloudFormation template.
+  `TechnicalId` is optional for Terraform onboarding — when omitted, the template
+  derives the IAM external ID from the CloudFormation stack ID (template 2.2 / CLO-906).
+change_logs: [user]


### PR DESCRIPTION
Adds the changelog entry required to cut a **patch release (v1.14.2)** so the AWS CloudFormation integration guide from #76 is published to the Terraform/OpenTofu registries.

No provider code changes — docs-only release.