### PR TITLE
fix(provider): fall back on id when resolving imports without an origin label

### DIFF
--- a/.chloggen/fix-import-resolver-id-fallback.yaml
+++ b/.chloggen/fix-import-resolver-id-fallback.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: provider
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Populate `id` and `url` in state after `terraform import` for assets that carry no `dash0.com/origin` label.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [135]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Assets originally created in the Dash0 UI have no `dash0.com/origin` label, so the previous
+  identifier resolver — which matched only on origin — left the imported resource's `id` and `url`
+  attributes empty (only a `TF_LOG=INFO` warning surfaced the miss). The resolver now falls back to
+  matching the imported identifier against each list item's internal id, so `id` and `url` are
+  populated for both CLI/API/Terraform-created assets (where the origin label is present) and
+  UI-created assets (where it is absent). Applies to dashboards, views, check rules, synthetic
+  checks, recording rules, spam filters, and notification channels.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/provider/client/client.go
+++ b/internal/provider/client/client.go
@@ -72,19 +72,31 @@ type Client interface {
 var _ Client = &dash0Client{}
 
 // matchOriginID returns the server-assigned internal id of the list item whose
-// origin matches the given origin, or an empty string when no item matches.
+// origin (or, as a fallback, whose id) matches the given identifier, or an
+// empty string when no item matches.
 //
 // The Dash0 web app addresses assets by their internal id, which the
-// single-asset endpoints do not return (they only echo the origin). The id is
-// therefore resolved from the list endpoint by matching on origin. The accessor
-// extracts the (id, origin) pair from each list item type.
-func matchOriginID[T any](items []*T, origin string, accessor func(*T) (string, *string)) string {
+// single-asset endpoints do not return (they only echo the identifier that was
+// used to fetch them). The id is therefore resolved from the list endpoint. The
+// resolver tries origin first, then falls back to matching the identifier
+// against the list item's id — this covers assets originally created in the
+// Dash0 UI, which carry no `dash0.com/origin` label. The API's GET/PUT
+// endpoints accept either an origin or an id as the identifier, so both
+// matching paths produce a consistent result: an origin-matched item's id is
+// what the deep-link builder needs, and an id-matched item is already indexed
+// by the value the caller passed in.
+//
+// The accessor extracts the (id, origin) pair from each list item type.
+func matchOriginID[T any](items []*T, identifier string, accessor func(*T) (string, *string)) string {
 	for _, item := range items {
 		if item == nil {
 			continue
 		}
 		id, itemOrigin := accessor(item)
-		if itemOrigin != nil && *itemOrigin == origin {
+		if itemOrigin != nil && *itemOrigin == identifier {
+			return id
+		}
+		if id != "" && id == identifier {
 			return id
 		}
 	}

--- a/internal/provider/client/dashboard_test.go
+++ b/internal/provider/client/dashboard_test.go
@@ -43,6 +43,30 @@ func TestMatchOriginID(t *testing.T) {
 	t.Run("no match returns empty", func(t *testing.T) {
 		assert.Equal(t, "", matchOriginID(items, "tf_missing", accessor))
 	})
+
+	t.Run("falls back to id match when origin is nil (UI-created asset)", func(t *testing.T) {
+		// The item without an origin label carries id "22222222-...". When the
+		// user imports that id as the identifier, the resolver must find it and
+		// return the same id so downstream URL construction still works.
+		assert.Equal(t, "22222222-2222-2222-2222-222222222222", matchOriginID(items, "22222222-2222-2222-2222-222222222222", accessor))
+	})
+
+	t.Run("falls back to id match when origin exists but does not match", func(t *testing.T) {
+		// The identifier "11111111-..." doesn't match any origin, but does match
+		// the first item's id. The resolver should still find it.
+		assert.Equal(t, "11111111-1111-1111-1111-111111111111", matchOriginID(items, "11111111-1111-1111-1111-111111111111", accessor))
+	})
+
+	t.Run("origin match takes precedence over id match on the same identifier", func(t *testing.T) {
+		// Contrived case: two items where item A has origin==X and item B has
+		// id==X. The origin match on A must fire first.
+		strPtr := func(s string) *string { return &s }
+		conflicting := []*dash0.DashboardApiListItem{
+			{Id: "aa", Origin: strPtr("shared-key")},
+			{Id: "shared-key", Origin: strPtr("bb")},
+		}
+		assert.Equal(t, "aa", matchOriginID(conflicting, "shared-key", accessor))
+	})
 }
 
 // TestGetDashboardURL verifies that GetDashboardURL resolves the internal id by

--- a/internal/provider/client/notification_channel.go
+++ b/internal/provider/client/notification_channel.go
@@ -83,13 +83,20 @@ func (c *dash0Client) ResolveNotificationChannel(ctx context.Context, origin str
 		return "", "", err
 	}
 
+	// Match on origin first, fall back to matching on id — see matchOriginID for
+	// the rationale (imports of UI-created channels have no origin label).
 	var id string
 	for _, channel := range channels {
 		if channel == nil {
 			continue
 		}
+		channelID := dash0.GetNotificationChannelID(channel)
 		if dash0.GetNotificationChannelOrigin(channel) == origin {
-			id = dash0.GetNotificationChannelID(channel)
+			id = channelID
+			break
+		}
+		if channelID != "" && channelID == origin {
+			id = channelID
 			break
 		}
 	}

--- a/internal/provider/client/notification_channel_test.go
+++ b/internal/provider/client/notification_channel_test.go
@@ -53,6 +53,16 @@ func TestResolveNotificationChannel(t *testing.T) {
 					},
 				},
 			},
+			{
+				Kind: "Dash0NotificationChannel",
+				Metadata: dash0.NotificationChannelMetadata{
+					Name: "UI-created",
+					Labels: &dash0.NotificationChannelLabels{
+						// UI-created channels carry only Dash0Comid, no Dash0Comorigin.
+						Dash0Comid: strPtr("22222222-2222-2222-2222-222222222222"),
+					},
+				},
+			},
 		})
 	}))
 	t.Cleanup(server.Close)
@@ -78,5 +88,14 @@ func TestResolveNotificationChannel(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "", id)
 		assert.Equal(t, "", url)
+	})
+
+	t.Run("UI-created channel resolves via id fallback (no origin label)", func(t *testing.T) {
+		// Imports of UI-created channels use the internal id as the identifier
+		// because the origin label is absent.
+		id, url, err := c.ResolveNotificationChannel(t.Context(), "22222222-2222-2222-2222-222222222222")
+		require.NoError(t, err)
+		assert.Equal(t, "22222222-2222-2222-2222-222222222222", id)
+		assert.Equal(t, "https://app.dash0.com/goto/settings/notifications?channel_id=22222222-2222-2222-2222-222222222222", url)
 	})
 }

--- a/internal/provider/client/recording_rule.go
+++ b/internal/provider/client/recording_rule.go
@@ -83,11 +83,14 @@ func (c *dash0Client) ResolveRecordingRule(ctx context.Context, origin string, d
 		return "", err
 	}
 
+	// Match on origin first, fall back to matching on id — see matchOriginID for
+	// the rationale (imports of UI-created rules have no origin label).
 	for _, rule := range items {
 		if rule == nil || rule.Metadata.Labels == nil {
 			continue
 		}
-		if (*rule.Metadata.Labels)[dash0.LabelOrigin] == origin {
+		labels := *rule.Metadata.Labels
+		if labels[dash0.LabelOrigin] == origin || (labels[dash0.LabelID] != "" && labels[dash0.LabelID] == origin) {
 			id := dash0.GetRecordingRuleID(rule)
 			tflog.Debug(ctx, fmt.Sprintf("Resolved recording rule id for origin %s: %s", origin, id))
 			return id, nil

--- a/internal/provider/client/spam_filter.go
+++ b/internal/provider/client/spam_filter.go
@@ -128,6 +128,8 @@ func (c *dash0Client) ResolveSpamFilter(ctx context.Context, origin string, data
 		return "", err
 	}
 
+	// Match on origin first, fall back to matching on id — see matchOriginID for
+	// the rationale (imports of UI-created filters have no origin label).
 	for _, obj := range items {
 		var meta *dash0.SpamFilterMetadata
 		switch f := obj.(type) {
@@ -140,18 +142,20 @@ func (c *dash0Client) ResolveSpamFilter(ctx context.Context, origin string, data
 				meta = &f.Metadata
 			}
 		}
-		if meta == nil || meta.Labels == nil || meta.Labels.Dash0Comorigin == nil {
+		if meta == nil || meta.Labels == nil {
 			continue
 		}
-		if *meta.Labels.Dash0Comorigin != origin {
-			continue
-		}
-		var id string
+		var itemID string
 		if meta.Labels.Dash0Comid != nil {
-			id = *meta.Labels.Dash0Comid
+			itemID = *meta.Labels.Dash0Comid
 		}
-		tflog.Debug(ctx, fmt.Sprintf("Resolved spam filter id for origin %s: %s", origin, id))
-		return id, nil
+		originMatches := meta.Labels.Dash0Comorigin != nil && *meta.Labels.Dash0Comorigin == origin
+		idMatches := itemID != "" && itemID == origin
+		if !originMatches && !idMatches {
+			continue
+		}
+		tflog.Debug(ctx, fmt.Sprintf("Resolved spam filter id for origin %s: %s", origin, itemID))
+		return itemID, nil
 	}
 
 	tflog.Warn(ctx, fmt.Sprintf("Spam filter with origin %q not found in dataset %q; id will be empty", origin, dataset))

--- a/internal/provider/client/view.go
+++ b/internal/provider/client/view.go
@@ -75,9 +75,19 @@ func (c *dash0Client) ResolveView(ctx context.Context, origin string, dataset st
 		return "", "", err
 	}
 
+	// Match on origin first, fall back to matching on id — see matchOriginID for
+	// the rationale. Views cannot use matchOriginID directly because they carry
+	// a Type field that ViewDeeplinkURL needs alongside the id.
 	var matched *dash0.ViewApiListItem
 	for _, item := range items {
-		if item != nil && item.Origin != nil && *item.Origin == origin {
+		if item == nil {
+			continue
+		}
+		if item.Origin != nil && *item.Origin == origin {
+			matched = item
+			break
+		}
+		if item.Id != "" && item.Id == origin {
 			matched = item
 			break
 		}

--- a/internal/provider/client/view_test.go
+++ b/internal/provider/client/view_test.go
@@ -32,6 +32,7 @@ func TestResolveView(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]dash0.ViewApiListItem{
 			{Id: "11111111-1111-1111-1111-111111111111", Origin: strPtr("tf_other"), Type: dash0.Logs},
+			{Id: "22222222-2222-2222-2222-222222222222", Origin: nil, Type: dash0.Logs}, // UI-created, no origin
 			{Id: "33333333-3333-3333-3333-333333333333", Origin: strPtr("tf_target"), Type: dash0.Spans},
 		})
 	}))
@@ -58,5 +59,14 @@ func TestResolveView(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "", id)
 		assert.Equal(t, "", url)
+	})
+
+	t.Run("UI-created view resolves via id fallback (no origin label)", func(t *testing.T) {
+		// Imports of UI-created views use the internal id as the identifier
+		// because the origin label is absent. The resolver must find them.
+		id, url, err := c.ResolveView(t.Context(), "22222222-2222-2222-2222-222222222222", "production")
+		require.NoError(t, err)
+		assert.Equal(t, "22222222-2222-2222-2222-222222222222", id)
+		assert.Equal(t, "https://app.dash0.com/goto/logs?dataset=production&view_id=22222222-2222-2222-2222-222222222222", url)
 	})
 }


### PR DESCRIPTION
Fixes #135 — `id` and `url` are now populated in state after `terraform import` for assets that carry no `dash0.com/origin` label (typical for UI-created assets).