### PR TITLE
fix(docs): repair operator URLs and preserve AWS section on regeneration

### DIFF
--- a/docs/resources/check_rule.md
+++ b/docs/resources/check_rule.md
@@ -4,14 +4,14 @@ page_title: "dash0_check_rule Resource - Dash0"
 subcategory: ""
 description: |-
   Manages a Dash0 Check Rule. Check rules define alerting conditions based on PromQL expressions that are continuously evaluated against your telemetry data. See About Alerting https://dash0.com/docs/dash0/monitoring/alerting/alerting and About Creating Check Rules https://dash0.com/docs/dash0/monitoring/alerting/create-check-rules for more details. The check rule definition uses the Prometheus Rule format https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/.
-  More information on how Prometheus rules are mapped to Dash0 check rules can be found in the Dash0 Operator documentation https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-check-rules.
+  More information on how Prometheus rules are mapped to Dash0 check rules can be found in the Dash0 Operator documentation https://dash0.com/docs/dash0/monitoring/kubernetes/dash0-operator/managing-dash0-resources#managing-dash0-check-rules.
 ---
 
 # dash0_check_rule (Resource)
 
 Manages a Dash0 Check Rule. Check rules define alerting conditions based on PromQL expressions that are continuously evaluated against your telemetry data. See [About Alerting](https://dash0.com/docs/dash0/monitoring/alerting/alerting) and [About Creating Check Rules](https://dash0.com/docs/dash0/monitoring/alerting/create-check-rules) for more details. The check rule definition uses the [Prometheus Rule format](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 
-More information on how Prometheus rules are mapped to Dash0 check rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-check-rules).
+More information on how Prometheus rules are mapped to Dash0 check rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/dash0-operator/managing-dash0-resources#managing-dash0-check-rules).
 
 ## Example Usage
 

--- a/docs/resources/recording_rule.md
+++ b/docs/resources/recording_rule.md
@@ -4,14 +4,11 @@ page_title: "dash0_recording_rule Resource - Dash0"
 subcategory: ""
 description: |-
   Manages a Dash0 Recording Rule. Recording rules pre-compute frequently needed or computationally expensive PromQL expressions and save the results as new time series. See Manage Check Rules as Code https://dash0.com/docs/dash0/monitoring/alerting/manage-check-rules-as-code for more details — recording rules share the same Prometheus rule format and management surface as alert check rules. The recording rule definition uses the Prometheus Rule format https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule.
-  More information on how Prometheus rules are mapped to Dash0 recording rules can be found in the Dash0 Operator documentation https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-recording-rules.
 ---
 
 # dash0_recording_rule (Resource)
 
 Manages a Dash0 Recording Rule. Recording rules pre-compute frequently needed or computationally expensive PromQL expressions and save the results as new time series. See [Manage Check Rules as Code](https://dash0.com/docs/dash0/monitoring/alerting/manage-check-rules-as-code) for more details — recording rules share the same Prometheus rule format and management surface as alert check rules. The recording rule definition uses the [Prometheus Rule format](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule).
-
-More information on how Prometheus rules are mapped to Dash0 recording rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-recording-rules).
 
 ## Example Usage
 

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -74,7 +74,7 @@ func (r *CheckRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	resp.Schema = schema.Schema{
 		Description: `Manages a Dash0 Check Rule. Check rules define alerting conditions based on PromQL expressions that are continuously evaluated against your telemetry data. See [About Alerting](https://dash0.com/docs/dash0/monitoring/alerting/alerting) and [About Creating Check Rules](https://dash0.com/docs/dash0/monitoring/alerting/create-check-rules) for more details. The check rule definition uses the [Prometheus Rule format](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 
-More information on how Prometheus rules are mapped to Dash0 check rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-check-rules).`,
+More information on how Prometheus rules are mapped to Dash0 check rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/dash0-operator/managing-dash0-resources#managing-dash0-check-rules).`,
 
 		Attributes: map[string]schema.Attribute{
 			"origin": schema.StringAttribute{

--- a/internal/provider/recording_rule_resource.go
+++ b/internal/provider/recording_rule_resource.go
@@ -71,9 +71,7 @@ func (r *RecordingRuleResource) Metadata(_ context.Context, req resource.Metadat
 
 func (r *RecordingRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: `Manages a Dash0 Recording Rule. Recording rules pre-compute frequently needed or computationally expensive PromQL expressions and save the results as new time series. See [Manage Check Rules as Code](https://dash0.com/docs/dash0/monitoring/alerting/manage-check-rules-as-code) for more details — recording rules share the same Prometheus rule format and management surface as alert check rules. The recording rule definition uses the [Prometheus Rule format](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule).
-
-More information on how Prometheus rules are mapped to Dash0 recording rules can be found in the [Dash0 Operator documentation](https://dash0.com/docs/dash0/monitoring/kubernetes/about-kubernetes#managing-dash0-recording-rules).`,
+		Description: `Manages a Dash0 Recording Rule. Recording rules pre-compute frequently needed or computationally expensive PromQL expressions and save the results as new time series. See [Manage Check Rules as Code](https://dash0.com/docs/dash0/monitoring/alerting/manage-check-rules-as-code) for more details — recording rules share the same Prometheus rule format and management surface as alert check rules. The recording rule definition uses the [Prometheus Rule format](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule).`,
 
 		Attributes: map[string]schema.Attribute{
 			"origin": schema.StringAttribute{

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -105,3 +105,7 @@ Run `dash0 auth login` to re-authenticate, then re-run your Terraform command.
 ### Managing Notification Channels
 
 {{ tffile "examples/resources/dash0_notification_channel/resource.tf" }}
+
+## AWS Integration with Dash0
+
+To deploy the Dash0 AWS integration via CloudFormation, see the [AWS Integration via CloudFormation](guides/aws_cloudformation_integration) guide.


### PR DESCRIPTION
The referenced pages at `/docs/dash0/monitoring/kubernetes/about-kubernetes` no longer carry `#managing-dash0-check-rules` or `#managing-dash0-recording-rules` anchors — the content moved to `/docs/dash0/monitoring/kubernetes/dash0-operator/managing-dash0-resources`. The dash0-website `check-links` CI job on the sync PR (dash0-website #609) fails on both broken anchors.

- **check_rule**: retarget to the new page, preserving the `#managing-dash0-check-rules` section pointer.
- **recording_rule**: drop the reference sentence entirely. The operator page's Check Rules section explicitly notes that PrometheusRule entries with `record:` are ignored (the operator uses a separate `Dash0RecordingRule` CRD for recording rules), so linking there for "how Prometheus rules map to recording rules" was misleading. The first-paragraph link to *Manage Check Rules as Code* already covers the PrometheusRule format.

Unblocks the check-links CI job on the dash0-website side of the sync PR.