### PR TITLE
docs(notification-channels): call out read-only spec.routing.assets in example and import guide

### DIFF
--- a/.chloggen/document-routing-assets-read-only.yaml
+++ b/.chloggen/document-routing-assets-read-only.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: notification_channels
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Document that `spec.routing.assets` is a read-only, server-derived back-reference in the routing example and the import guide"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [128]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Dash0 API populates `spec.routing.assets` when a check rule or synthetic check binds to the
+  channel and discards any value supplied on write; the provider already warns when it is set and
+  excludes it from drift comparison. The routing example and the import guide now say so explicitly.

--- a/docs/guides/import-existing-assets.md
+++ b/docs/guides/import-existing-assets.md
@@ -197,6 +197,9 @@ Beyond that, three things are worth spot-checking:
 - **`id` and `url` attributes.** Both are computed after import — `id` is Dash0's server-assigned UUID, `url` deep-links into the Dash0 web app.
   Neither round-trips into Dash0; they exist so other resources can reference the imported asset.
 - **Cross-resource references.** A `dash0_check_rule` that names a `dash0_notification_channel` by its `id` in the `dash0.com/notification-channel-ids` annotation still resolves after an import — the channel's `id` attribute is populated during import, just as it is after a Terraform-driven create.
+- **Read-only `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
+  It is a server-derived back-reference: the API discards any value supplied on write (the provider warns if you set it), and the provider excludes it from drift comparison.
+  Bind a check rule via its `dash0.com/notification-channel-ids` annotation, or a synthetic check via its `spec.notifications.channels`.
 
 ~> **Note:** A stubborn `plan` diff on a `dash0_spam_filter` import that survives re-exporting the YAML is almost always an `apiVersion` mismatch — the provider dispatches on it, so `apiVersion: v1alpha1` (the older `spec.contexts` list shape) and `apiVersion: v1alpha2` (the newer `spec.context` single-value shape) are treated as distinct schemas.
 

--- a/docs/guides/import-existing-assets.md
+++ b/docs/guides/import-existing-assets.md
@@ -197,7 +197,7 @@ Beyond that, three things are worth spot-checking:
 - **`id` and `url` attributes.** Both are computed after import — `id` is Dash0's server-assigned UUID, `url` deep-links into the Dash0 web app.
   Neither round-trips into Dash0; they exist so other resources can reference the imported asset.
 - **Cross-resource references.** A `dash0_check_rule` that names a `dash0_notification_channel` by its `id` in the `dash0.com/notification-channel-ids` annotation still resolves after an import — the channel's `id` attribute is populated during import, just as it is after a Terraform-driven create.
-- **Read-only `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
+- **API-managed `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
   It is a server-derived back-reference: the API discards any value supplied on write (the provider warns if you set it), and the provider excludes it from drift comparison.
   Bind a check rule via its `dash0.com/notification-channel-ids` annotation, or a synthetic check via its `spec.notifications.channels`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -489,7 +489,7 @@ YAML
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
 #
-# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# Note: `routing` also has an API-managed `assets` sibling — the Dash0 API populates it as a
 # back-reference when a check rule or synthetic check binds to the channel, and discards any
 # value supplied on write (the provider warns if you set it). Bind a check rule via its
 # `dash0.com/notification-channel-ids` annotation, or a synthetic check via its

--- a/docs/index.md
+++ b/docs/index.md
@@ -488,6 +488,12 @@ YAML
 # In this example, notifications are sent when:
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
+#
+# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# back-reference when a check rule or synthetic check binds to the channel, and discards any
+# value supplied on write (the provider warns if you set it). Bind a check rule via its
+# `dash0.com/notification-channel-ids` annotation, or a synthetic check via its
+# `spec.notifications.channels`.
 resource "dash0_notification_channel" "webhook_with_routing" {
   notification_channel_yaml = <<-YAML
 kind: Dash0NotificationChannel

--- a/docs/resources/notification_channel.md
+++ b/docs/resources/notification_channel.md
@@ -168,6 +168,12 @@ YAML
 # In this example, notifications are sent when:
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
+#
+# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# back-reference when a check rule or synthetic check binds to the channel, and discards any
+# value supplied on write (the provider warns if you set it). Bind a check rule via its
+# `dash0.com/notification-channel-ids` annotation, or a synthetic check via its
+# `spec.notifications.channels`.
 resource "dash0_notification_channel" "webhook_with_routing" {
   notification_channel_yaml = <<-YAML
 kind: Dash0NotificationChannel

--- a/docs/resources/notification_channel.md
+++ b/docs/resources/notification_channel.md
@@ -169,7 +169,7 @@ YAML
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
 #
-# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# Note: `routing` also has an API-managed `assets` sibling — the Dash0 API populates it as a
 # back-reference when a check rule or synthetic check binds to the channel, and discards any
 # value supplied on write (the provider warns if you set it). Bind a check rule via its
 # `dash0.com/notification-channel-ids` annotation, or a synthetic check via its

--- a/examples/resources/dash0_notification_channel/resource.tf
+++ b/examples/resources/dash0_notification_channel/resource.tf
@@ -148,7 +148,7 @@ YAML
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
 #
-# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# Note: `routing` also has an API-managed `assets` sibling — the Dash0 API populates it as a
 # back-reference when a check rule or synthetic check binds to the channel, and discards any
 # value supplied on write (the provider warns if you set it). Bind a check rule via its
 # `dash0.com/notification-channel-ids` annotation, or a synthetic check via its

--- a/examples/resources/dash0_notification_channel/resource.tf
+++ b/examples/resources/dash0_notification_channel/resource.tf
@@ -147,6 +147,12 @@ YAML
 # In this example, notifications are sent when:
 #   (team.name = "sre" AND deployment.environment.name = "production")
 #   OR (service.severity = "critical")
+#
+# Note: `routing` also has a read-only `assets` sibling — the Dash0 API populates it as a
+# back-reference when a check rule or synthetic check binds to the channel, and discards any
+# value supplied on write (the provider warns if you set it). Bind a check rule via its
+# `dash0.com/notification-channel-ids` annotation, or a synthetic check via its
+# `spec.notifications.channels`.
 resource "dash0_notification_channel" "webhook_with_routing" {
   notification_channel_yaml = <<-YAML
 kind: Dash0NotificationChannel

--- a/internal/provider/notification_channel_resource.go
+++ b/internal/provider/notification_channel_resource.go
@@ -43,7 +43,7 @@ var notificationChannelAlwaysIgnoredFields = []string{
 
 // warnIfRoutingAssetsSet emits a Warning when the user's YAML declares a
 // non-empty spec.routing.assets list. The Dash0 API discards this field on
-// write, so the value will not take effect; binding a check rule or synthetic
+// write, leaving existing bindings unaffected; binding a check rule or synthetic
 // check to a notification channel must be expressed on the check resource.
 func warnIfRoutingAssetsSet(channelYaml string, diags *diag.Diagnostics) {
 	var parsed map[string]interface{}
@@ -66,8 +66,8 @@ func warnIfRoutingAssetsSet(channelYaml string, diags *diag.Diagnostics) {
 		"spec.routing.assets is API-managed and ignored on write",
 		"The Dash0 API populates spec.routing.assets as a back-reference when "+
 			"other resources bind to this notification channel by id, and "+
-			"discards any value supplied on write. The entries you provided "+
-			"will not take effect. To bind a check rule, set the annotation "+
+			"discards any value supplied on write. Existing bindings "+
+			"are unaffected. To bind a check rule, set the annotation "+
 			"dash0.com/notification-channel-ids on the check rule; to bind a "+
 			"synthetic check, set spec.notifications.channels on the "+
 			"synthetic check.",

--- a/templates/guides/import-existing-assets.md.tmpl
+++ b/templates/guides/import-existing-assets.md.tmpl
@@ -197,6 +197,9 @@ Beyond that, three things are worth spot-checking:
 - **`id` and `url` attributes.** Both are computed after import — `id` is Dash0's server-assigned UUID, `url` deep-links into the Dash0 web app.
   Neither round-trips into Dash0; they exist so other resources can reference the imported asset.
 - **Cross-resource references.** A `dash0_check_rule` that names a `dash0_notification_channel` by its `id` in the `dash0.com/notification-channel-ids` annotation still resolves after an import — the channel's `id` attribute is populated during import, just as it is after a Terraform-driven create.
+- **Read-only `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
+  It is a server-derived back-reference: the API discards any value supplied on write (the provider warns if you set it), and the provider excludes it from drift comparison.
+  Bind a check rule via its `dash0.com/notification-channel-ids` annotation, or a synthetic check via its `spec.notifications.channels`.
 
 ~> **Note:** A stubborn `plan` diff on a `dash0_spam_filter` import that survives re-exporting the YAML is almost always an `apiVersion` mismatch — the provider dispatches on it, so `apiVersion: v1alpha1` (the older `spec.contexts` list shape) and `apiVersion: v1alpha2` (the newer `spec.context` single-value shape) are treated as distinct schemas.
 

--- a/templates/guides/import-existing-assets.md.tmpl
+++ b/templates/guides/import-existing-assets.md.tmpl
@@ -197,7 +197,7 @@ Beyond that, three things are worth spot-checking:
 - **`id` and `url` attributes.** Both are computed after import — `id` is Dash0's server-assigned UUID, `url` deep-links into the Dash0 web app.
   Neither round-trips into Dash0; they exist so other resources can reference the imported asset.
 - **Cross-resource references.** A `dash0_check_rule` that names a `dash0_notification_channel` by its `id` in the `dash0.com/notification-channel-ids` annotation still resolves after an import — the channel's `id` attribute is populated during import, just as it is after a Terraform-driven create.
-- **Read-only `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
+- **API-managed `spec.routing.assets` on imported channels.** An imported `dash0_notification_channel` that check rules or synthetic checks bind to shows a populated `spec.routing.assets` — do not copy it into your configuration.
   It is a server-derived back-reference: the API discards any value supplied on write (the provider warns if you set it), and the provider excludes it from drift comparison.
   Bind a check rule via its `dash0.com/notification-channel-ids` annotation, or a synthetic check via its `spec.notifications.channels`.
 


### PR DESCRIPTION
## What

Documentation polish only — no behavior change:

- The `webhook_with_routing` example in `examples/resources/dash0_notification_channel/resource.tf` now notes that `routing` has a read-only `assets` sibling: the API populates it as a back-reference when a check rule or synthetic check binds to the channel, and discards any value supplied on write (the provider already warns via `ValidateConfig`).
- The import guide (`templates/guides/import-existing-assets.md.tmpl`) now tells users not to copy an imported channel's populated `routing.assets` into their config.
- Regenerated docs via `make docs` + `.chloggen` entry.

## Why

The provider already handled this field correctly (warns on non-empty `assets`, ignores it in drift comparison — see #128), but the example and import guide never explained it, so imported channels kept tripping users into copying the field. Part of the INS-458 resolution; companion PRs: dash0hq/dash0#15826, dash0hq/dash0-api-client-go#25, dash0hq/dash0-cli#239.

## Testing

- `go test ./internal/...` green; `make docs` idempotent; `make chlog-validate` green. (`test-roundtrip` needs live API credentials and was skipped as usual for local runs.)