### PR TITLE
fix(provider): refresh OAuth access tokens throughout a run

### DIFF
--- a/.chloggen/iac-1-oauth-token-refresh.yaml
+++ b/.chloggen/iac-1-oauth-token-refresh.yaml
@@ -1,0 +1,20 @@
+change_type: bug_fix
+
+component: provider
+
+note: Refresh OAuth access tokens throughout a plan or apply, and fix named OAuth profiles never refreshing
+
+issues: [161]
+
+subtext: |
+  Credentials from an OAuth-enabled Dash0 CLI profile were captured once, when the provider
+  was configured, then reused for the rest of the run. A Dash0 OAuth access token lasts 15
+  minutes, so a plan or apply over a large configuration failed with 401 partway through. The
+  token is now refreshed as needed for the whole run, which is what the documentation already
+  described.
+
+  A named profile, `provider "dash0" { profile = "production" }`, had it worse: it was never
+  refreshed, so it failed as soon as the stored token was over 15 minutes old. Only the active
+  profile was refreshed, and only at configure time. Named profiles now behave the same.
+
+  Static credentials from `DASH0_AUTH_TOKEN` or the `auth_token` attribute are unaffected.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dash0hq/terraform-provider-dash0
 go 1.26.2
 
 require (
-	github.com/dash0hq/dash0-api-client-go v1.20.0
+	github.com/dash0hq/dash0-api-client-go v1.21.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-github.com/dash0hq/dash0-api-client-go v1.20.0 h1:u0rLjG+Su8qTZvwLu8df+E2QvwXGC83GGihJ8fam+SA=
-github.com/dash0hq/dash0-api-client-go v1.20.0/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
+github.com/dash0hq/dash0-api-client-go v1.21.0 h1:O+pghZKfVDmz5Mp1B8o5pYXzLerYd+oklXMu4euqa00=
+github.com/dash0hq/dash0-api-client-go v1.21.0/go.mod h1:+PufWHDFteVN4eG28EDCjnSQF8vUneO92tnEw39SiRY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/provider/check_rule_resource_acc_test.go
+++ b/internal/provider/check_rule_resource_acc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -345,7 +346,7 @@ func testAccCheckCheckRuleHasMergedAnnotation(resourceName, annotationKey, expec
 
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)
@@ -398,7 +399,7 @@ func testAccCheckCheckRuleExists(resourceName string) resource.TestCheckFunc {
 		// Create a new client to verify the check rule exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/client/check_rule_test.go
+++ b/internal/provider/client/check_rule_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNewDash0Client_CheckRule(t *testing.T) {
 	// Verify client creation works (check rule methods are available on the client)
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
+	c, err := NewDash0Client("https://api.example.com", dash0.StaticAuthTokenProvider("auth_test-token"), "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }

--- a/internal/provider/client/client_test.go
+++ b/internal/provider/client/client_test.go
@@ -5,15 +5,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func TestNewDash0Client(t *testing.T) {
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
+	c, err := NewDash0Client("https://api.example.com", dash0.StaticAuthTokenProvider("auth_test-token"), "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
+// TestNewDash0Client_InvalidToken documents that a malformed token is no longer
+// rejected when the client is constructed.
+//
+// Authentication is resolved per request now, so the token's shape is checked
+// when a request is about to go out rather than up front -- a provider may not
+// have a token to hand at construction time. Users still get a fast, actionable
+// error: the provider's Configure validates the prefix before reaching this
+// constructor. See TestDash0Provider_Configure_InvalidAuthToken.
 func TestNewDash0Client_InvalidToken(t *testing.T) {
-	_, err := NewDash0Client("https://api.example.com", "invalid-token", "test", 3)
-	assert.Error(t, err)
+	c, err := NewDash0Client("https://api.example.com", dash0.StaticAuthTokenProvider("invalid-token"), "test", 3)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 }

--- a/internal/provider/client/dash0.go
+++ b/internal/provider/client/dash0.go
@@ -15,10 +15,18 @@ type dash0Client struct {
 }
 
 // NewDash0Client creates a new Dash0 API client backed by the shared library.
-func NewDash0Client(url, authToken, version string, maxRetries int) (*dash0Client, error) {
+//
+// Authentication goes through an [dash0.AuthTokenProvider] rather than a fixed
+// token so that an OAuth access token is refreshed for the whole duration of a
+// Terraform run. An access token is valid for 15 minutes, and a plan or apply
+// over a large configuration routinely takes longer than that; a token captured
+// once at Configure time would start failing with 401 partway through.
+// Credentials that cannot expire — a static `auth_*` token from the environment
+// or the provider block — are passed as a static provider.
+func NewDash0Client(url string, authTokenProvider dash0.AuthTokenProvider, version string, maxRetries int) (*dash0Client, error) {
 	c, err := dash0.NewClient(
 		dash0.WithApiUrl(url),
-		dash0.WithAuthToken(authToken),
+		dash0.WithAuthTokenProvider(authTokenProvider),
 		dash0.WithUserAgent(fmt.Sprintf("Dash0 Terraform Provider/%s", version)),
 		dash0.WithMaxRetries(maxRetries),
 	)

--- a/internal/provider/client/recording_rule_test.go
+++ b/internal/provider/client/recording_rule_test.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
 
 func TestNewDash0Client_RecordingRule(t *testing.T) {
 	// Verify client creation works (recording rule methods are available on the client)
-	c, err := NewDash0Client("https://api.example.com", "auth_test-token", "test", 3)
+	c, err := NewDash0Client("https://api.example.com", dash0.StaticAuthTokenProvider("auth_test-token"), "test", 3)
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }

--- a/internal/provider/dashboard_resource_acc_test.go
+++ b/internal/provider/dashboard_resource_acc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -184,7 +185,7 @@ func testAccCheckDashboardExists(resourceName string) resource.TestCheckFunc {
 		// Create a new c to verify the dashboard exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/notification_channel_resource_acc_test.go
+++ b/internal/provider/notification_channel_resource_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -127,7 +128,7 @@ func testAccCheckNotificationChannelExists(resourceName string) resource.TestChe
 		// Create a new client to verify the notification channel exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/oauth_token_refresh_test.go
+++ b/internal/provider/oauth_token_refresh_test.go
@@ -1,0 +1,248 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
+)
+
+// oauthTokenServer stands in for the Dash0 authorization server and records how
+// often a refresh-grant exchange happened.
+type oauthTokenServer struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	calls int
+}
+
+func newOAuthTokenServer(t *testing.T) *oauthTokenServer {
+	t.Helper()
+	s := &oauthTokenServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		s.mu.Lock()
+		s.calls++
+		call := s.calls
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  fmt.Sprintf("dash0_at_refreshed-%d", call),
+			"refresh_token": fmt.Sprintf("rt-%d", call),
+			"token_type":    "Bearer",
+			"expires_in":    int64((15 * time.Minute).Seconds()),
+		})
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *oauthTokenServer) exchanges() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// oauthProfilesJSON builds a profiles.json holding one OAuth profile and one
+// static profile, with the OAuth access token expiring at the given offset.
+func oauthProfilesJSON(apiUrl string, expiresAt time.Time) string {
+	return fmt.Sprintf(`{
+  "profiles": [
+    {
+      "name": "oauth-profile",
+      "configuration": {
+        "apiUrl": %q,
+        "authToken": "dash0_at_stale",
+        "oauth": {
+          "clientId": "cid",
+          "refreshToken": "rt-0",
+          "expiresAt": %q
+        }
+      }
+    },
+    {
+      "name": "static-profile",
+      "configuration": {
+        "apiUrl": %q,
+        "authToken": "auth_static_token"
+      }
+    }
+  ]
+}`, apiUrl, expiresAt.UTC().Format(time.RFC3339Nano), apiUrl)
+}
+
+// TestResolveAuthInfo_RecordsProfileName pins the plumbing the refresh depends
+// on: without a profile name the token provider has no profile to write
+// refreshed tokens back to.
+func TestResolveAuthInfo_RecordsProfileName(t *testing.T) {
+	ctx := context.Background()
+	server := newOAuthTokenServer(t)
+	fixture := oauthProfilesJSON(server.URL, time.Now().Add(1*time.Hour))
+
+	t.Run("active profile", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "oauth-profile", fixture)
+
+		auth, err := resolveAuthInfo(ctx, &providerConfigModel{})
+		require.NoError(t, err)
+		require.NotNil(t, auth.profileCfg)
+		assert.Equal(t, "oauth-profile", auth.profileCfg.ProfileName)
+	})
+
+	t.Run("named profile", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "static-profile", fixture)
+
+		auth, err := resolveAuthInfo(ctx, &providerConfigModel{
+			Profile: types.StringValue("oauth-profile"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, auth.profileCfg)
+		assert.Equal(t, "oauth-profile", auth.profileCfg.ProfileName)
+	})
+}
+
+// TestAuthInfoTokenProvider_NamedOAuthProfileRefreshes is the regression test for
+// the named-profile half of #161.
+//
+// Before the fix, `provider "dash0" { profile = "production" }` used whatever
+// access token was on disk without ever refreshing it, so it failed as soon as
+// that token was more than 15 minutes old. Only the active-profile path
+// refreshed.
+//
+// The refresh happens in the token provider, not while loading the profile, so
+// a run that never uses the profile's credentials never spends an exchange.
+func TestAuthInfoTokenProvider_NamedOAuthProfileRefreshes(t *testing.T) {
+	ctx := context.Background()
+	server := newOAuthTokenServer(t)
+	// Already expired, which is the normal state of a stored token: they live
+	// for 15 minutes and Terraform runs are not that frequent.
+	fixture := oauthProfilesJSON(server.URL, time.Now().Add(-1*time.Hour))
+
+	clearCredentialEnv(t)
+	setupCLIConfigDir(t, "static-profile", fixture)
+
+	auth, err := resolveAuthInfo(ctx, &providerConfigModel{
+		Profile: types.StringValue("oauth-profile"),
+	})
+	require.NoError(t, err)
+	require.True(t, auth.isOAuth)
+	// Loading the profile is a disk read. It reports the stale token and does
+	// not exchange anything, so a run that authenticates with an auth_token
+	// from the provider block never rotates the profile's refresh token.
+	assert.Equal(t, "dash0_at_stale", auth.token,
+		"loading a profile must not exchange a token")
+	assert.Equal(t, 0, server.exchanges(), "expected no refresh-grant exchange at load time")
+
+	// The provider is what refreshes, and it does so before the first request
+	// rather than leaving Terraform with the expired token.
+	provider := auth.tokenProvider()
+	authToken, err := provider.AuthToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "dash0_at_refreshed-1", authToken,
+		"a named OAuth profile must refresh its expired access token")
+	assert.Equal(t, 1, server.exchanges(), "expected exactly one refresh-grant exchange")
+
+	// The fresh token is then served from memory.
+	authToken, err = provider.AuthToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "dash0_at_refreshed-1", authToken)
+	assert.Equal(t, 1, server.exchanges(), "the fresh token must not trigger a second exchange")
+}
+
+// TestAuthInfoTokenProvider_RefreshesForTheWholeRun covers the long-apply half of
+// #161: the provider is configured once, but the token it authenticates with
+// must not be frozen at that moment.
+func TestAuthInfoTokenProvider_RefreshesForTheWholeRun(t *testing.T) {
+	ctx := context.Background()
+	server := newOAuthTokenServer(t)
+	// Inside the five-minute refresh threshold.
+	fixture := oauthProfilesJSON(server.URL, time.Now().Add(1*time.Minute))
+
+	clearCredentialEnv(t)
+	setupCLIConfigDir(t, "oauth-profile", fixture)
+
+	auth, err := resolveAuthInfo(ctx, &providerConfigModel{})
+	require.NoError(t, err)
+
+	provider := auth.tokenProvider()
+	refresher, ok := provider.(dash0.RefreshingAuthTokenProvider)
+	require.True(t, ok, "an OAuth profile must yield a refreshing provider so a 401 can be recovered from")
+
+	first, err := provider.AuthToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "dash0_at_refreshed-1", first)
+
+	// A second request inside the new token's validity must reuse it rather than
+	// exchange again, or a long apply would hammer the token endpoint.
+	second, err := provider.AuthToken(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, server.exchanges())
+
+	// A 401 forces a replacement even though the current token looks healthy.
+	// Passing the token that was rejected is what lets the provider tell this
+	// apart from a sibling request that already rotated it.
+	forced, err := refresher.ForceRefreshAuthToken(ctx, second)
+	require.NoError(t, err)
+	assert.Equal(t, "dash0_at_refreshed-2", forced)
+	assert.Equal(t, 2, server.exchanges())
+
+	// A caller rejected while holding an already-superseded token gets the
+	// current one back rather than triggering another rotation.
+	deduped, err := refresher.ForceRefreshAuthToken(ctx, second)
+	require.NoError(t, err)
+	assert.Equal(t, "dash0_at_refreshed-2", deduped)
+	assert.Equal(t, 2, server.exchanges(), "a superseded stale token must not rotate again")
+}
+
+// TestAuthInfoTokenProvider_StaticCredentialsAreNotRefreshed guards the
+// non-OAuth paths: a static token must be served as-is, with no refresh attempt
+// and no dependency on a CLI profile being present.
+func TestAuthInfoTokenProvider_StaticCredentialsAreNotRefreshed(t *testing.T) {
+	ctx := context.Background()
+	server := newOAuthTokenServer(t)
+
+	t.Run("environment credentials", func(t *testing.T) {
+		clearCredentialEnv(t)
+		t.Setenv("DASH0_API_URL", server.URL)
+		t.Setenv("DASH0_AUTH_TOKEN", "auth_from_env")
+
+		auth, err := resolveAuthInfo(ctx, &providerConfigModel{})
+		require.NoError(t, err)
+		assert.False(t, auth.isOAuth)
+
+		authToken, err := auth.tokenProvider().AuthToken(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "auth_from_env", authToken)
+		assert.Equal(t, 0, server.exchanges())
+	})
+
+	t.Run("static CLI profile", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "static-profile", oauthProfilesJSON(server.URL, time.Now().Add(-1*time.Hour)))
+
+		auth, err := resolveAuthInfo(ctx, &providerConfigModel{})
+		require.NoError(t, err)
+		assert.False(t, auth.isOAuth)
+
+		authToken, err := auth.tokenProvider().AuthToken(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "auth_static_token", authToken)
+		assert.Equal(t, 0, server.exchanges())
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	dash0Profiles "github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
@@ -98,10 +99,10 @@ func getEnvURL() string {
 // which honors the DASH0_CONFIG_DIR environment variable and falls back to
 // `~/.dash0`.
 //
-// When the resolved profile uses OAuth, the access token is transparently
-// refreshed (if close to expiry) for the active-profile path. Named profiles
-// that are not active cannot be refreshed because the library does not expose a
-// public per-name refresh API; the provider will use whatever token is on disk.
+// Both paths record which profile the configuration came from, which is what
+// lets the client refresh its OAuth access token per request. A hand-rolled
+// search through GetProfiles drops that, leaving a configuration that can only
+// serve whatever token happens to sit on disk.
 func loadProfileConfiguration(ctx context.Context, profileName string) (*dash0Profiles.Configuration, error) {
 	store, err := dash0Profiles.NewStore()
 	if err != nil {
@@ -115,25 +116,41 @@ func loadProfileConfiguration(ctx context.Context, profileName string) (*dash0Pr
 		}
 		return cfg, nil
 	}
-	profiles, err := store.GetProfiles()
+	cfg, err := store.GetConfigurationForProfile(ctx, profileName)
+	if errors.Is(err, dash0Profiles.ErrProfileNotFound) {
+		return nil, fmt.Errorf("profile %q not found in dash0 CLI configuration", profileName)
+	}
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range profiles {
-		if p.Name == profileName {
-			return &p.Configuration, nil
-		}
-	}
-	return nil, fmt.Errorf("profile %q not found in dash0 CLI configuration", profileName)
+	return cfg, nil
 }
 
 // authInfo holds the resolved Dash0 URL, auth token, and whether the token
 // originated from an OAuth-enabled CLI profile (in which case the auth_
 // prefix validation is skipped).
+//
+// profileCfg is the CLI profile the credentials came from, or nil when they came
+// from the environment or the provider block. It is retained so the client can
+// be built around a refreshing token provider instead of the token snapshot in
+// the token field, which is only used for validation and logging.
 type authInfo struct {
-	url     string
-	token   string
-	isOAuth bool
+	url        string
+	token      string
+	isOAuth    bool
+	profileCfg *dash0Profiles.Configuration
+}
+
+// tokenProvider returns how the API client should authenticate.
+//
+// An OAuth profile yields a provider that refreshes the access token as it nears
+// expiry, so a long plan or apply is not cut off mid-run. Everything else is a
+// credential that does not expire, so it is served as-is.
+func (a authInfo) tokenProvider() dash0.AuthTokenProvider {
+	if a.isOAuth && a.profileCfg != nil {
+		return a.profileCfg.AuthTokenProvider()
+	}
+	return dash0.StaticAuthTokenProvider(a.token)
 }
 
 // resolveAuthInfo computes the Dash0 URL and auth token according to the
@@ -189,7 +206,7 @@ func resolveAuthInfo(ctx context.Context, cfg *providerConfigModel) (authInfo, e
 		authToken = profileCfg.AuthToken
 		isOAuth = profileCfg.OAuth != nil
 	}
-	return authInfo{url: url, token: authToken, isOAuth: isOAuth}, nil
+	return authInfo{url: url, token: authToken, isOAuth: isOAuth, profileCfg: profileCfg}, nil
 }
 
 // Configure prepares a Dash0 API client for data sources and resources.
@@ -285,7 +302,7 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 	tflog.Debug(ctx, "Creating Dash0 client")
 
 	// Create dash0Client configuration for data sources and resources
-	dash0Client, err := client.NewDash0Client(auth.url, auth.token, p.version, maxRetries)
+	dash0Client, err := client.NewDash0Client(auth.url, auth.tokenProvider(), p.version, maxRetries)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Dash0 API Client",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -241,6 +241,25 @@ func TestDash0Provider_Configure_MissingAuthToken(t *testing.T) {
 	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Missing Dash0 Auth Token")
 }
 
+// TestDash0Provider_Configure_InvalidAuthToken covers the only remaining check
+// on a malformed token. The API client validates a token's shape per request
+// now, not at construction, so this is what turns a typo into an immediate,
+// actionable Terraform diagnostic instead of a failure on the first API call.
+func TestDash0Provider_Configure_InvalidAuthToken(t *testing.T) {
+	clearCredentialEnv(t)
+
+	p := &dash0Provider{}
+	req := provider.ConfigureRequest{
+		Config: providerTestConfig(strPtr("https://api.example.com"), strPtr("nonsense-token"), nil, nil),
+	}
+	resp := &provider.ConfigureResponse{}
+	p.Configure(context.Background(), req, resp)
+
+	assert.True(t, resp.Diagnostics.HasError())
+	require.Len(t, resp.Diagnostics.Errors(), 1)
+	assert.Contains(t, resp.Diagnostics.Errors()[0].Summary(), "Invalid Dash0 Auth Token")
+}
+
 func TestDash0Provider_Configure_MissingBoth(t *testing.T) {
 	clearCredentialEnv(t)
 

--- a/internal/provider/recording_rule_resource_acc_test.go
+++ b/internal/provider/recording_rule_resource_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -157,7 +158,7 @@ func testAccCheckRecordingRuleExists(resourceName string) resource.TestCheckFunc
 		// Create a new client to verify the recording rule exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/spam_filter_resource_acc_test.go
+++ b/internal/provider/spam_filter_resource_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -160,7 +161,7 @@ func testAccCheckSpamFilterExists(resourceName string) resource.TestCheckFunc {
 		// Create a new client to verify the spam filter exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/synthetic_check_resource_acc_test.go
+++ b/internal/provider/synthetic_check_resource_acc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -329,7 +330,7 @@ func testAccCheckSyntheticCheckExists(resourceName string) resource.TestCheckFun
 		// Create a new client to verify the synthetic check exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/team_resource_acc_test.go
+++ b/internal/provider/team_resource_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -146,7 +147,7 @@ func testAccCheckTeamExists(resourceName string) resource.TestCheckFunc {
 
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)

--- a/internal/provider/view_resource_acc_test.go
+++ b/internal/provider/view_resource_acc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 )
 
@@ -284,7 +285,7 @@ func testAccCheckViewExists(resourceName string) resource.TestCheckFunc {
 		// Create a new client to verify the view exists
 		c, err := client.NewDash0Client(
 			os.Getenv("DASH0_URL"),
-			os.Getenv("DASH0_AUTH_TOKEN"),
+			dash0.StaticAuthTokenProvider(os.Getenv("DASH0_AUTH_TOKEN")),
 			"test",
 			3,
 		)


### PR DESCRIPTION
Fixes #161

## Problem

Credentials from an OAuth CLI profile are captured once at configure time. Access tokens live 15 minutes, so a plan or apply over a large configuration starts failing with 401 partway through. A named profile, `provider "dash0" { profile = "production" }`, was never refreshed at any point, because `loadProfileConfiguration` hand-rolled `GetProfiles` plus a search by name. That made it unusable whenever the stored token was over 15 minutes old.

Our docs already claim the provider "refreshes automatically before every request", so this closes a gap against documented behavior.

## Solution

`NewDash0Client` takes an `AuthTokenProvider` instead of a token string. OAuth profiles get a refreshing provider, while env vars and the `auth_token` attribute get a static one, so all three credential sources converge on one path. Named profiles are resolved through the profiles package, so they behave exactly like the active profile.