### PR TITLE
feat(provider): add a provider-level dataset default

### DIFF
--- a/.chloggen/worktree-provider-attribute-dataset.yaml
+++ b/.chloggen/worktree-provider-attribute-dataset.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: provider
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add a provider-level `dataset` default and make the per-resource `dataset` attribute optional on dashboards, check rules, recording rules, spam filters, synthetic checks, and views"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [158]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The default resolves from the `DASH0_DATASET` environment variable, then the provider's `dataset`
+  attribute, then the dash0 CLI profile's dataset, then "default". Existing configurations that set
+  `dataset` explicitly on every resource keep working unchanged.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,7 @@ Credentials can also be sourced from a [Dash0 CLI](https://dash0.com/docs/dash0/
 | `auth_token` | string (sensitive) | Conditional | Dash0 auth token. Must start with `auth_` (static token) or `dash0_at_` (OAuth access token). Required unless `DASH0_AUTH_TOKEN` is set or a CLI profile supplies it. |
 | `otlp_url` | string | Optional | Base URL of the Dash0 OTLP/HTTP ingress endpoint (for example, `https://ingress.us-west-2.aws.dash0.com`). Find yours on the [OTLP endpoint settings page](https://app.dash0.com/goto/settings/endpoints?endpoint_type=otlp_http). A different host from `url`. Only the `dash0_log_event` and `dash0_deployment_event` actions need it; every resource works without it. Signal-specific paths such as `/v1/logs` are appended automatically and must not be included. |
 | `profile` | string | Optional | Name of a Dash0 CLI profile whose credentials should be used. Only consulted when neither environment variables nor the `url`/`auth_token`/`otlp_url` attributes are set. |
+| `dataset` | string | Optional | Default dataset used by dataset-scoped resources (dashboards, check rules, recording rules, spam filters, synthetic checks, views) that omit their own `dataset` attribute. Default: `DASH0_DATASET`, then the CLI profile's dataset, then `"default"`. |
 | `max_retries` | number | Optional | Maximum number of retries for failed API requests. Range: `0`–`5`. Default: `3`. |
 
 ## Environment variables
@@ -24,6 +25,7 @@ Environment variables take precedence over the equivalent `provider` block attri
 | `DASH0_AUTH_TOKEN` | Yes¹ | The API auth token for Dash0. Must start with `auth_` or `dash0_at_`. Overrides the `auth_token` provider attribute. | — |
 | `DASH0_OTLP_URL` | No | Base URL of the Dash0 OTLP/HTTP ingress endpoint. Find yours on the [OTLP endpoint settings page](https://app.dash0.com/goto/settings/endpoints?endpoint_type=otlp_http). Overrides the `otlp_url` provider attribute. Only needed by the log-event actions. | — |
 | `DASH0_CONFIG_DIR` | No | Directory containing the Dash0 CLI configuration files (`activeProfile`, `profiles.json`). Used when loading credentials from a CLI profile. | `~/.dash0` |
+| `DASH0_DATASET` | No | Default dataset used by dataset-scoped resources that omit their own `dataset` attribute. Overrides the `dataset` provider attribute. | `"default"` |
 | `DASH0_MAX_RETRIES` | No | Maximum number of retries for failed API requests (0–5). Overrides the `max_retries` provider attribute. | `3` |
 
 ¹ Required unless credentials are supplied through the `provider` block or a Dash0 CLI profile.
@@ -119,3 +121,33 @@ Run `dash0 auth login` to re-authenticate, then re-run your Terraform command.
 ~> **Note:** OAuth support was added in version [v1.14.0](https://github.com/dash0hq/terraform-provider-dash0/releases/tag/v1.14.0). Earlier versions reject OAuth-enabled profiles with an `Invalid Dash0 Auth Token` error because they require auth tokens to start with the `auth_` prefix — OAuth access tokens use `dash0_at_` instead, so upgrade the provider if you see this error.
 
 ~> **Note:** The `dash0_log_event` and `dash0_deployment_event` actions require a static token (`auth_` prefix, from [Dash0 Settings > Auth Tokens](https://app.dash0.com/goto/settings/auth-tokens)) — supplied via `auth_token`, `DASH0_AUTH_TOKEN`, or a non-OAuth profile. The Dash0 OTLP/HTTP ingress endpoint those actions send to does not accept OAuth access tokens, even though the Dash0 API does, so an OAuth-enabled profile fails those actions with an actionable error.
+
+## Default dataset
+
+Every dataset-scoped resource (`dash0_dashboard`, `dash0_check_rule`, `dash0_recording_rule`, `dash0_spam_filter`, `dash0_synthetic_check`, `dash0_view`) accepts its own `dataset` attribute.
+That attribute is optional: when a resource omits it, the resource inherits the provider-level default instead.
+
+The default resolves in this order and stops at the first source that supplies it:
+
+1. The `DASH0_DATASET` environment variable.
+2. The `dataset` attribute on the `provider` block.
+3. The dataset configured on the resolved Dash0 CLI profile.
+4. `"default"`.
+
+```terraform
+provider "dash0" {
+  dataset = "production"
+}
+
+resource "dash0_dashboard" "checkout" {
+  # No dataset needed -- inherits "production" from the provider block.
+  dashboard_yaml = file("checkout.yaml")
+}
+
+resource "dash0_dashboard" "staging_canary" {
+  dataset        = "staging" # Still overridable per resource.
+  dashboard_yaml = file("canary.yaml")
+}
+```
+
+~> **Note:** A resource's inherited dataset is resolved once, at create time, and then pinned into state. Changing the provider-level `dataset` afterward does not move existing resources — it only affects resources created after the change. To move an existing resource to a different dataset, set its own `dataset` attribute explicitly; that still forces the resource to be recreated, exactly as changing `dataset` on any dataset-scoped resource always has.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ The following environment variables are supported:
 | `DASH0_AUTH_TOKEN` | Yes | The API auth token for Dash0. Must start with `auth_` or `dash0_at_`. Overrides the `auth_token` provider attribute. | — |
 | `DASH0_OTLP_URL` | No | The base URL of the Dash0 OTLP/HTTP ingress endpoint (e.g. `https://ingress.us-west-2.aws.dash0.com`). Find yours on the [OTLP endpoint settings page](https://app.dash0.com/goto/settings/endpoints?endpoint_type=otlp_http). Overrides the `otlp_url` provider attribute. Only needed by the `dash0_log_event` and `dash0_deployment_event` actions. | — |
 | `DASH0_CONFIG_DIR` | No | Directory containing the dash0 CLI configuration files (`activeProfile`, `profiles.json`). Used when loading credentials from a CLI profile. | `~/.dash0` |
+| `DASH0_DATASET` | No | Default dataset used by dataset-scoped resources that omit their own `dataset` attribute. Overrides the `dataset` provider attribute. | `"default"` |
 | `DASH0_MAX_RETRIES` | No | Maximum number of retries for failed API requests (0–5). Overrides the `max_retries` provider attribute. | `3` |
 
 ### Option 2: Provider Configuration
@@ -106,6 +107,47 @@ If you see this error, upgrade the provider to the latest version.
 
 **Note:** The `dash0_log_event` and `dash0_deployment_event` actions require a static token (`auth_` prefix, from [Dash0 Settings > Auth Tokens](https://app.dash0.com/goto/settings/auth-tokens)) — supplied via `auth_token`, `DASH0_AUTH_TOKEN`, or a non-OAuth profile.
 The Dash0 OTLP/HTTP ingress endpoint those actions send to does not accept OAuth access tokens, even though the Dash0 API does, so an OAuth-enabled profile fails those actions with an actionable error.
+
+## Default dataset
+
+Dataset-scoped resources (`dash0_dashboard`, `dash0_check_rule`, `dash0_recording_rule`, `dash0_spam_filter`, `dash0_synthetic_check`, `dash0_view`) accept an optional `dataset` attribute.
+When a resource omits it, the resource inherits a provider-level default resolved in this order:
+
+1. The `DASH0_DATASET` environment variable.
+2. The `dataset` provider attribute.
+3. The dataset configured on the resolved dash0 CLI profile.
+4. `"default"`.
+
+```terraform
+terraform {
+  required_providers {
+    dash0 = {
+      source  = "dash0hq/dash0"
+      version = "~> 1.6.0"
+    }
+  }
+}
+
+# The `dataset` attribute sets the default dataset for resources that omit
+# their own `dataset` attribute. DASH0_DATASET and the dash0 CLI profile's
+# dataset are consulted first; see the "Default dataset" section for the full
+# precedence order.
+provider "dash0" {
+  dataset = "production"
+}
+
+resource "dash0_dashboard" "checkout" {
+  # No dataset needed -- inherits "production" from the provider block.
+  dashboard_yaml = file("checkout.yaml")
+}
+
+resource "dash0_dashboard" "staging_canary" {
+  dataset        = "staging" # Still overridable per resource.
+  dashboard_yaml = file("canary.yaml")
+}
+```
+
+~> **Note:** A resource's inherited dataset is resolved once, at create time, and pinned into state. Changing the provider-level `dataset` afterward does not move existing resources. To move a resource, set its own `dataset` attribute, which forces the resource to be recreated as it always does.
 
 ## Examples
 

--- a/docs/resources/check_rule.md
+++ b/docs/resources/check_rule.md
@@ -214,7 +214,10 @@ Use one spelling throughout a document.
 ### Required
 
 - `check_rule_yaml` (String) The check rule definition in YAML format, following the [Prometheus alerting rule specification](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/). Must contain exactly one group with exactly one rule. The document's top-level `metadata.annotations` are merged into the rule's own annotations, and the rule's own annotations take precedence when the same key is set in both places, so a document written for the Dash0 Kubernetes operator can be used here verbatim. Setting `dash0.com/sharing` controls sharing, and changes to it trigger a resource update.
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -25,7 +25,10 @@ resource "dash0_dashboard" "my_dashboard" {
 ### Required
 
 - `dashboard_yaml` (String) The dashboard definition in YAML format, following the [Perses Dashboard specification](https://dash0.com/docs/dash0/dashboards/reference-dashboard-source-format). The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/recording_rule.md
+++ b/docs/resources/recording_rule.md
@@ -39,8 +39,11 @@ EOF
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `recording_rule_yaml` (String) The recording rule definition in YAML format, following the [Prometheus recording rule specification](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/spam_filter.md
+++ b/docs/resources/spam_filter.md
@@ -58,8 +58,11 @@ EOF
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `spam_filter_yaml` (String) The spam filter definition in YAML format. The YAML must include a `metadata.name` field and a `spec` with a `filter` (list of key-value matchers) and either `contexts` (`v1alpha1`, a list of signal types: `log`, `span`, `datapoint` or `web_event`) or `context` (`v1alpha2`, a single signal type out of `log`, `span`, `datapoint` or `web_event`). The `apiVersion` field determines which shape is expected.
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/synthetic_check.md
+++ b/docs/resources/synthetic_check.md
@@ -99,8 +99,11 @@ YAML
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `synthetic_check_yaml` (String) The synthetic check definition in YAML format, specifying the check type, target URL, schedule, and assertion criteria. See [Create Synthetic Checks](https://dash0.com/docs/dash0/monitoring/synthetics/create-synthetic-checks) for the available options. The `dash0.com/sharing` metadata annotation is supported to control sharing settings; changes to it trigger a resource update. All other metadata annotations are managed by the server and ignored during drift detection.
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -24,8 +24,11 @@ resource "dash0_view" "my_check" {
 
 ### Required
 
-- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.
 - `view_yaml` (String) The view definition in YAML format, specifying the filters, queries, and display settings for the view. The following `metadata.annotations` are supported: `dash0.com/sharing` (sharing settings) and `dash0.com/folder-path` (folder location). Changes to these annotations trigger a resource update; all other metadata annotations are managed by the server and ignored during drift detection.
+
+### Optional
+
+- `dataset` (String) The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.
 
 ### Read-Only
 

--- a/examples/provider/provider_with_dataset.tf
+++ b/examples/provider/provider_with_dataset.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    dash0 = {
+      source  = "dash0hq/dash0"
+      version = "~> 1.6.0"
+    }
+  }
+}
+
+# The `dataset` attribute sets the default dataset for resources that omit
+# their own `dataset` attribute. DASH0_DATASET and the dash0 CLI profile's
+# dataset are consulted first; see the "Default dataset" section for the full
+# precedence order.
+provider "dash0" {
+  dataset = "production"
+}
+
+resource "dash0_dashboard" "checkout" {
+  # No dataset needed -- inherits "production" from the provider block.
+  dashboard_yaml = file("checkout.yaml")
+}
+
+resource "dash0_dashboard" "staging_canary" {
+  dataset        = "staging" # Still overridable per resource.
+  dashboard_yaml = file("canary.yaml")
+}

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -100,8 +100,8 @@ More information on how Prometheus rules are mapped to Dash0 check rules can be 
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"check_rule_yaml": schema.StringAttribute{

--- a/internal/provider/check_rule_resource.go
+++ b/internal/provider/check_rule_resource.go
@@ -37,6 +37,9 @@ func NewCheckRuleResource() resource.Resource {
 // CheckRuleResource is the resource implementation.
 type CheckRuleResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // checkRuleModel is the Terraform state model for a check rule resource.
@@ -54,16 +57,17 @@ func (r *CheckRuleResource) Configure(_ context.Context, req resource.ConfigureR
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *CheckRuleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -92,10 +96,12 @@ More information on how Prometheus rules are mapped to Dash0 check rules can be 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the check rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"check_rule_yaml": schema.StringAttribute{
@@ -144,6 +150,9 @@ func (r *CheckRuleResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var checkRuleYaml interface{}

--- a/internal/provider/check_rule_resource_test.go
+++ b/internal/provider/check_rule_resource_test.go
@@ -88,10 +88,11 @@ func TestCheckRuleResource_Schema(t *testing.T) {
 	assert.True(t, originAttr.IsComputed())
 	assert.False(t, originAttr.IsRequired())
 
-	// Verify dataset is required
+	// Verify dataset is optional, inherited from the provider default when omitted
 	datasetAttr := resp.Schema.Attributes["dataset"]
-	assert.True(t, datasetAttr.IsRequired())
-	assert.False(t, datasetAttr.IsComputed())
+	assert.False(t, datasetAttr.IsRequired())
+	assert.True(t, datasetAttr.IsOptional())
+	assert.True(t, datasetAttr.IsComputed())
 
 	// Verify check_rule_yaml is required
 	yamlAttr := resp.Schema.Attributes["check_rule_yaml"]
@@ -113,7 +114,7 @@ func TestCheckRuleResource_Configure(t *testing.T) {
 	}{
 		{
 			name:         "valid client interface",
-			providerData: &MockClient{},
+			providerData: resourceProviderData{client: &MockClient{}, defaultDataset: "default"},
 			expectError:  false,
 		},
 		{

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -37,6 +37,9 @@ func NewDashboardResource() resource.Resource {
 // DashboardResource is the resource implementation.
 type DashboardResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // dashboardModel is the Terraform state model for a dashboard resource.
@@ -54,16 +57,17 @@ func (r *DashboardResource) Configure(_ context.Context, req resource.ConfigureR
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *DashboardResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -89,10 +93,12 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the dashboard belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"dashboard_yaml": schema.StringAttribute{
@@ -141,6 +147,9 @@ func (r *DashboardResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var dashboardYaml interface{}

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -97,8 +97,8 @@ func (r *DashboardResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"dashboard_yaml": schema.StringAttribute{

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -144,63 +144,10 @@ func TestDashboardResource_Create(t *testing.T) {
 	assert.Equal(t, testURL, resultState.URL.ValueString())
 }
 
-func TestDashboardResource_Create_InheritsDefaultDataset(t *testing.T) {
-	mockClient := new(MockClient)
-	r := &DashboardResource{client: mockClient, defaultDataset: "provider-default-dataset"}
-
-	testYaml := "kind: Dashboard\nmetadata:\n  name: system-overview\nspec:\n  title: System Overview"
-
-	datasetSchema := schema.Schema{
-		Attributes: map[string]schema.Attribute{
-			"origin": schema.StringAttribute{
-				Computed: true,
-			},
-			"id": schema.StringAttribute{
-				Computed: true,
-			},
-			"dataset": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
-			},
-			"dashboard_yaml": schema.StringAttribute{
-				Required: true,
-			},
-			"url": schema.StringAttribute{
-				Computed: true,
-			},
-		},
-	}
-
-	// The `dataset` attribute is omitted from the plan (unknown, as it would be
-	// for a Computed attribute with no matching prior state), simulating a
-	// config that relies on the provider-level default.
-	plan := tfsdk.Plan{
-		Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
-			"origin":         tftypes.NewValue(tftypes.String, ""),
-			"id":             tftypes.NewValue(tftypes.String, nil),
-			"dataset":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-			"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
-			"url":            tftypes.NewValue(tftypes.String, nil),
-		}),
-		Schema: datasetSchema,
-	}
-
-	req := resource.CreateRequest{Plan: plan}
-	resp := resource.CreateResponse{State: tfsdk.State{Schema: datasetSchema}}
-
-	mockClient.On("CreateDashboard", mock.Anything, mock.Anything, mock.Anything, "provider-default-dataset").Return(nil)
-	mockClient.On("ResolveDashboard", mock.Anything, mock.Anything, "provider-default-dataset").Return("test-id", "", nil)
-
-	r.Create(context.Background(), req, &resp)
-
-	assert.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
-	mockClient.AssertExpectations(t)
-
-	var resultState dashboardModel
-	diags := resp.State.Get(context.Background(), &resultState)
-	require.False(t, diags.HasError(), "state cannot be unmarshalled")
-	assert.Equal(t, "provider-default-dataset", resultState.Dataset.ValueString())
-}
+// Dataset default-inheritance and plan-modifier behavior (omitted dataset
+// pinning to prior state, explicit changes still requiring replacement) are
+// covered table-driven across all six dataset-scoped resources in
+// dataset_default_test.go, rather than per-resource here.
 
 func TestDashboardResource_Read(t *testing.T) {
 	mockClient := new(MockClient)

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -43,7 +43,8 @@ func TestDashboardResource_Schema(t *testing.T) {
 
 	// Check specific attribute properties
 	assert.True(t, resp.Schema.Attributes["origin"].(schema.StringAttribute).Computed)
-	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Required)
+	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Optional)
+	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Computed)
 	assert.True(t, resp.Schema.Attributes["dashboard_yaml"].(schema.StringAttribute).Required)
 	assert.True(t, resp.Schema.Attributes["url"].(schema.StringAttribute).Computed)
 }
@@ -60,8 +61,9 @@ func TestDashboardResource_Configure(t *testing.T) {
 
 	// Test with valid provider data
 	resp = &resource.ConfigureResponse{}
-	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, resp)
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: resourceProviderData{client: client, defaultDataset: "default"}}, resp)
 	assert.Equal(t, client, r.client)
+	assert.Equal(t, "default", r.defaultDataset)
 	assert.False(t, resp.Diagnostics.HasError())
 
 	// Test with invalid provider data
@@ -140,6 +142,64 @@ func TestDashboardResource_Create(t *testing.T) {
 	diags := resp.State.Get(context.Background(), &resultState)
 	require.False(t, diags.HasError(), "state cannot be unmarshalled")
 	assert.Equal(t, testURL, resultState.URL.ValueString())
+}
+
+func TestDashboardResource_Create_InheritsDefaultDataset(t *testing.T) {
+	mockClient := new(MockClient)
+	r := &DashboardResource{client: mockClient, defaultDataset: "provider-default-dataset"}
+
+	testYaml := "kind: Dashboard\nmetadata:\n  name: system-overview\nspec:\n  title: System Overview"
+
+	datasetSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"origin": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"dataset": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"dashboard_yaml": schema.StringAttribute{
+				Required: true,
+			},
+			"url": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+
+	// The `dataset` attribute is omitted from the plan (unknown, as it would be
+	// for a Computed attribute with no matching prior state), simulating a
+	// config that relies on the provider-level default.
+	plan := tfsdk.Plan{
+		Raw: tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{
+			"origin":         tftypes.NewValue(tftypes.String, ""),
+			"id":             tftypes.NewValue(tftypes.String, nil),
+			"dataset":        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			"dashboard_yaml": tftypes.NewValue(tftypes.String, testYaml),
+			"url":            tftypes.NewValue(tftypes.String, nil),
+		}),
+		Schema: datasetSchema,
+	}
+
+	req := resource.CreateRequest{Plan: plan}
+	resp := resource.CreateResponse{State: tfsdk.State{Schema: datasetSchema}}
+
+	mockClient.On("CreateDashboard", mock.Anything, mock.Anything, mock.Anything, "provider-default-dataset").Return(nil)
+	mockClient.On("ResolveDashboard", mock.Anything, mock.Anything, "provider-default-dataset").Return("test-id", "", nil)
+
+	r.Create(context.Background(), req, &resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
+	mockClient.AssertExpectations(t)
+
+	var resultState dashboardModel
+	diags := resp.State.Get(context.Background(), &resultState)
+	require.False(t, diags.HasError(), "state cannot be unmarshalled")
+	assert.Equal(t, "provider-default-dataset", resultState.Dataset.ValueString())
 }
 
 func TestDashboardResource_Read(t *testing.T) {

--- a/internal/provider/dataset_default_test.go
+++ b/internal/provider/dataset_default_test.go
@@ -1,0 +1,330 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// datasetInheritanceCase describes one dataset-scoped resource for the
+// table-driven tests below. Each resource has its own Create path and client
+// call, so the table captures just enough to drive Create and read back the
+// resolved dataset generically.
+type datasetInheritanceCase struct {
+	name        string
+	newResource func() resource.Resource
+	yamlAttr    string
+	yamlValue   string
+	hasURL      bool
+	// mockSetup registers the Create<X>/Resolve<X> expectations for a Create
+	// call that is expected to use dataset as the resolved dataset.
+	mockSetup func(m *MockClient, dataset string)
+}
+
+var datasetInheritanceCases = []datasetInheritanceCase{
+	{
+		name:        "dashboard",
+		newResource: NewDashboardResource,
+		yamlAttr:    "dashboard_yaml",
+		yamlValue:   "kind: Dashboard\nmetadata:\n  name: system-overview\nspec:\n  title: System Overview",
+		hasURL:      true,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateDashboard", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveDashboard", mock.Anything, mock.Anything, dataset).Return("test-id", "", nil)
+		},
+	},
+	{
+		name:        "check_rule",
+		newResource: NewCheckRuleResource,
+		yamlAttr:    "check_rule_yaml",
+		yamlValue: `apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rule
+spec:
+  groups:
+    - name: TestGroup
+      rules:
+        - alert: TestAlert
+          expr: up == 0
+          for: 5m`,
+		hasURL: true,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateCheckRule", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveCheckRule", mock.Anything, mock.Anything, dataset).Return("test-id", "", nil)
+		},
+	},
+	{
+		name:        "recording_rule",
+		newResource: NewRecordingRuleResource,
+		yamlAttr:    "recording_rule_yaml",
+		yamlValue: `apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-recording-rule
+spec:
+  groups:
+    - name: TestGroup
+      rules:
+        - record: test_metric
+          expr: sum(rate(http_requests_total[5m]))`,
+		hasURL: false,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateRecordingRule", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveRecordingRule", mock.Anything, mock.Anything, dataset).Return("test-id", nil)
+		},
+	},
+	{
+		name:        "spam_filter",
+		newResource: NewSpamFilterResource,
+		yamlAttr:    "spam_filter_yaml",
+		yamlValue: `apiVersion: v1alpha1
+kind: Dash0SpamFilter
+metadata:
+  name: Drop noisy health checks
+spec:
+  contexts:
+    - log
+  filter:
+    - key: "k8s.namespace.name"
+      operator: "is"
+      value: "kube-system"`,
+		hasURL: false,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateSpamFilter", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveSpamFilter", mock.Anything, mock.Anything, dataset).Return("test-id", nil)
+		},
+	},
+	{
+		name:        "synthetic_check",
+		newResource: NewSyntheticCheckResource,
+		yamlAttr:    "synthetic_check_yaml",
+		yamlValue: `
+kind: Dash0SyntheticCheck
+metadata:
+  name: examplecom
+spec:
+  enabled: true
+  plugin:
+    kind: http
+    spec:
+      request:
+        url: https://www.example.com`,
+		hasURL: true,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateSyntheticCheck", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveSyntheticCheck", mock.Anything, mock.Anything, dataset).Return("test-id", "", nil)
+		},
+	},
+	{
+		name:        "view",
+		newResource: NewViewResource,
+		yamlAttr:    "view_yaml",
+		yamlValue:   "kind: View\nmetadata:\n  name: example-view\nspec:\n  title: Example View",
+		hasURL:      true,
+		mockSetup: func(m *MockClient, dataset string) {
+			m.On("CreateView", mock.Anything, mock.Anything, mock.Anything, dataset).Return(nil)
+			m.On("ResolveView", mock.Anything, mock.Anything, dataset).Return("test-id", "", nil)
+		},
+	},
+}
+
+// buildOmittedDatasetCreatePlan builds a minimal Create plan for a
+// dataset-scoped resource where `dataset` is omitted from config. For an
+// Optional+Computed attribute with no config value and no prior state, the
+// framework's planned value is unknown -- exactly as it would be for a real
+// `terraform plan` on a new resource that relies on the provider default.
+func buildOmittedDatasetCreatePlan(yamlAttr, yamlValue string, hasURL bool) tfsdk.Plan {
+	attrTypes := map[string]tftypes.Type{
+		"origin":  tftypes.String,
+		"id":      tftypes.String,
+		"dataset": tftypes.String,
+		yamlAttr:  tftypes.String,
+	}
+	attrValues := map[string]tftypes.Value{
+		"origin":  tftypes.NewValue(tftypes.String, ""),
+		"id":      tftypes.NewValue(tftypes.String, nil),
+		"dataset": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		yamlAttr:  tftypes.NewValue(tftypes.String, yamlValue),
+	}
+	schemaAttrs := map[string]schema.Attribute{
+		"origin":  schema.StringAttribute{Computed: true},
+		"id":      schema.StringAttribute{Computed: true},
+		"dataset": schema.StringAttribute{Optional: true, Computed: true},
+		yamlAttr:  schema.StringAttribute{Required: true},
+	}
+	if hasURL {
+		attrTypes["url"] = tftypes.String
+		attrValues["url"] = tftypes.NewValue(tftypes.String, nil)
+		schemaAttrs["url"] = schema.StringAttribute{Computed: true}
+	}
+	return tfsdk.Plan{
+		Raw:    tftypes.NewValue(tftypes.Object{AttributeTypes: attrTypes}, attrValues),
+		Schema: schema.Schema{Attributes: schemaAttrs},
+	}
+}
+
+// TestDatasetScopedResources_Create_InheritsProviderDefaultDataset covers all
+// six dataset-scoped resources, verifying each resource's own Create path
+// falls back to the provider-level default dataset when the resource omits
+// its own `dataset` attribute. Each resource has a distinct client call, so
+// this cannot be collapsed into a single shared code path -- the table
+// exists precisely to exercise all six independently.
+func TestDatasetScopedResources_Create_InheritsProviderDefaultDataset(t *testing.T) {
+	const providerDefault = "provider-default-dataset"
+
+	for _, tc := range datasetInheritanceCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.newResource()
+
+			mockClient := new(MockClient)
+			tc.mockSetup(mockClient, providerDefault)
+
+			configurable, ok := r.(resource.ResourceWithConfigure)
+			require.True(t, ok, "%s must implement resource.ResourceWithConfigure", tc.name)
+
+			configureResp := &resource.ConfigureResponse{}
+			configurable.Configure(context.Background(), resource.ConfigureRequest{
+				ProviderData: resourceProviderData{client: mockClient, defaultDataset: providerDefault},
+			}, configureResp)
+			require.False(t, configureResp.Diagnostics.HasError(), "configure diagnostics: %v", configureResp.Diagnostics.Errors())
+
+			plan := buildOmittedDatasetCreatePlan(tc.yamlAttr, tc.yamlValue, tc.hasURL)
+			createReq := resource.CreateRequest{Plan: plan}
+			createResp := resource.CreateResponse{State: tfsdk.State{Schema: plan.Schema}}
+
+			r.Create(context.Background(), createReq, &createResp)
+
+			require.False(t, createResp.Diagnostics.HasError(), "create diagnostics: %v", createResp.Diagnostics.Errors())
+			mockClient.AssertExpectations(t)
+
+			var dataset types.String
+			diags := createResp.State.GetAttribute(context.Background(), path.Root("dataset"), &dataset)
+			require.False(t, diags.HasError(), "GetAttribute diagnostics: %v", diags.Errors())
+			assert.Equal(t, providerDefault, dataset.ValueString())
+		})
+	}
+}
+
+// datasetSchemaCase is the minimal descriptor needed to fetch a resource's
+// real `dataset` schema attribute for the plan-modifier tests below.
+type datasetSchemaCase struct {
+	name        string
+	newResource func() resource.Resource
+}
+
+var datasetSchemaCases = []datasetSchemaCase{
+	{"dashboard", NewDashboardResource},
+	{"check_rule", NewCheckRuleResource},
+	{"recording_rule", NewRecordingRuleResource},
+	{"spam_filter", NewSpamFilterResource},
+	{"synthetic_check", NewSyntheticCheckResource},
+	{"view", NewViewResource},
+}
+
+// nonNullEmptyObject returns a known (non-null), attribute-less object value,
+// used to stand in for tfsdk.State.Raw / tfsdk.Plan.Raw when a plan modifier
+// only cares whether the resource is being created (null state) or destroyed
+// (null plan), not about any other attribute.
+func nonNullEmptyObject() tftypes.Value {
+	return tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}, map[string]tftypes.Value{})
+}
+
+// runStringPlanModifiers replicates the terraform-plugin-framework's
+// sequential plan-modifier chaining for a single attribute: each modifier's
+// PlanValue output becomes the next modifier's PlanValue input, while
+// RequiresReplace accumulates across the whole chain and is never unset by a
+// later modifier. See fwserver's attribute plan modification loop, which this
+// mirrors, for the authoritative behavior.
+func runStringPlanModifiers(ctx context.Context, modifiers []planmodifier.String, req planmodifier.StringRequest) (finalValue types.String, requiresReplace bool) {
+	value := req.PlanValue
+	for _, m := range modifiers {
+		stepReq := req
+		stepReq.PlanValue = value
+		stepResp := &planmodifier.StringResponse{PlanValue: value}
+		m.PlanModifyString(ctx, stepReq, stepResp)
+		value = stepResp.PlanValue
+		if stepResp.RequiresReplace {
+			requiresReplace = true
+		}
+	}
+	return value, requiresReplace
+}
+
+// TestDatasetScopedResources_DatasetPlanModifiers exercises the `dataset`
+// attribute's real plan modifiers -- UseStateForUnknown then RequiresReplace
+// -- for all six dataset-scoped resources, at the planning stage rather than
+// through Create. This is deliberately independent of any provider-level
+// default: plan modifiers never see the provider configuration, so a
+// resource's own prior state is the only thing an omitted `dataset` can pin
+// to. That is what makes "changing the provider default does not move
+// existing resources" true, and this test is what proves it holds for every
+// resource, not just at the Create-time default-resolution level covered
+// above.
+//
+// The order of these two modifiers matters: RequiresReplace must run after
+// UseStateForUnknown resolves the omitted attribute back to its known prior
+// value. Running it first would compare the not-yet-resolved unknown planned
+// value against the known state value on every single update -- unrelated or
+// not -- and force replacement every time a resource with an inherited
+// dataset was updated at all.
+func TestDatasetScopedResources_DatasetPlanModifiers(t *testing.T) {
+	ctx := context.Background()
+	nonNullState := tfsdk.State{Raw: nonNullEmptyObject()}
+	nonNullPlan := tfsdk.Plan{Raw: nonNullEmptyObject()}
+
+	for _, tc := range datasetSchemaCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.newResource()
+			schemaResp := &resource.SchemaResponse{}
+			r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+			datasetAttr, ok := schemaResp.Schema.Attributes["dataset"].(schema.StringAttribute)
+			require.True(t, ok, "%s: dataset attribute must be a StringAttribute", tc.name)
+			modifiers := datasetAttr.PlanModifiers
+			require.NotEmpty(t, modifiers, "%s: dataset attribute must have plan modifiers", tc.name)
+
+			t.Run("omitted dataset on update inherits and pins the prior state, without requiring replacement", func(t *testing.T) {
+				req := planmodifier.StringRequest{
+					State:       nonNullState,
+					Plan:        nonNullPlan,
+					ConfigValue: types.StringNull(),
+					PlanValue:   types.StringUnknown(),
+					StateValue:  types.StringValue("prior-dataset"),
+				}
+
+				finalValue, requiresReplace := runStringPlanModifiers(ctx, modifiers, req)
+
+				assert.Equal(t, "prior-dataset", finalValue.ValueString(),
+					"an omitted dataset must be pinned to the resource's own prior state, independent of any provider-level default")
+				assert.False(t, requiresReplace,
+					"omitting dataset on an otherwise unrelated update must not force replacement")
+			})
+
+			t.Run("an explicit resource-level dataset change still requires replacement", func(t *testing.T) {
+				req := planmodifier.StringRequest{
+					State:       nonNullState,
+					Plan:        nonNullPlan,
+					ConfigValue: types.StringValue("new-dataset"),
+					PlanValue:   types.StringValue("new-dataset"),
+					StateValue:  types.StringValue("prior-dataset"),
+				}
+
+				finalValue, requiresReplace := runStringPlanModifiers(ctx, modifiers, req)
+
+				assert.Equal(t, "new-dataset", finalValue.ValueString())
+				assert.True(t, requiresReplace, "an explicit dataset change must still force replacement")
+			})
+		})
+	}
+}

--- a/internal/provider/notification_channel_resource.go
+++ b/internal/provider/notification_channel_resource.go
@@ -106,16 +106,16 @@ func (r *NotificationChannelResource) Configure(_ context.Context, req resource.
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
 }
 
 func (r *NotificationChannelResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/notification_channel_resource_test.go
+++ b/internal/provider/notification_channel_resource_test.go
@@ -89,7 +89,7 @@ func TestNotificationChannelResource_Configure(t *testing.T) {
 	}{
 		{
 			name:         "valid client interface",
-			providerData: &MockClient{},
+			providerData: resourceProviderData{client: &MockClient{}},
 			expectError:  false,
 		},
 		{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,7 +48,17 @@ type providerConfigModel struct {
 	AuthToken  types.String `tfsdk:"auth_token"`
 	OtlpURL    types.String `tfsdk:"otlp_url"`
 	Profile    types.String `tfsdk:"profile"`
+	Dataset    types.String `tfsdk:"dataset"`
 	MaxRetries types.Int64  `tfsdk:"max_retries"`
+}
+
+// resourceProviderData is what Configure stores as resp.ResourceData. It
+// bundles the API client with the provider-level default dataset so
+// dataset-scoped resources can inherit it when their own `dataset` attribute
+// is omitted, without every resource re-deriving the default itself.
+type resourceProviderData struct {
+	client         client.Client
+	defaultDataset string
 }
 
 // Metadata returns the provider type name.
@@ -77,6 +87,10 @@ func providerSchema() schema.Schema {
 			"profile": schema.StringAttribute{
 				Optional:    true,
 				Description: "The name of a [dash0 CLI](https://github.com/dash0hq/dash0-cli) profile to load credentials from when `url`/`auth_token`/`otlp_url` are not supplied via attributes or environment variables. If unset, the active profile in the dash0 CLI configuration directory is used. The directory defaults to `~/.dash0` and can be overridden with the DASH0_CONFIG_DIR environment variable.",
+			},
+			"dataset": schema.StringAttribute{
+				Optional:    true,
+				Description: "The default [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) used by dataset-scoped resources (dashboards, check rules, recording rules, spam filters, synthetic checks, and views) that omit their own `dataset` attribute. If omitted, the DASH0_DATASET environment variable is used, then the dataset configured on the resolved dash0 CLI profile, then \"default\". A resource can still override this per resource via its own `dataset` attribute.",
 			},
 			"max_retries": schema.Int64Attribute{
 				Optional:    true,
@@ -258,6 +272,47 @@ func resolveAuthInfo(ctx context.Context, cfg *providerConfigModel) (authInfo, e
 	return authInfo{url: url, token: authToken, otlpURL: otlpURL, isOAuth: isOAuthAccessToken(authToken), profileCfg: profileCfg}, nil
 }
 
+// resolveDataset computes the provider-level default dataset that
+// dataset-scoped resources inherit when their own `dataset` attribute is
+// omitted. Dataset is not an auth concern, so this is a sibling of
+// resolveAuthInfo rather than folded into it, and it follows the same
+// precedence pattern:
+//
+//  1. DASH0_DATASET environment variable.
+//  2. The `dataset` provider attribute.
+//  3. The dash0 CLI profile named by `profile` (or the active profile).
+//  4. "default".
+//
+// profileCfg is the configuration resolveAuthInfo already loaded, when
+// available, so the profile file is not read twice in the common case. It is
+// nil when resolveAuthInfo never consulted a profile (credentials were
+// already complete from env vars/attributes); a profile is then loaded here
+// as a best-effort second attempt. Unlike resolveAuthInfo, a profile load
+// failure here is silently ignored: dataset resolution never fails provider
+// configuration, it just falls through to "default".
+func resolveDataset(ctx context.Context, cfg *providerConfigModel, profileCfg *dash0Profiles.Configuration) string {
+	var attrDataset string
+	if !cfg.Dataset.IsNull() && !cfg.Dataset.IsUnknown() {
+		attrDataset = cfg.Dataset.ValueString()
+	}
+	if dataset := cmp.Or(os.Getenv("DASH0_DATASET"), attrDataset); dataset != "" {
+		return dataset
+	}
+
+	if profileCfg == nil {
+		var profileName string
+		if !cfg.Profile.IsNull() && !cfg.Profile.IsUnknown() {
+			profileName = cfg.Profile.ValueString()
+		}
+		profileCfg, _ = loadProfileConfiguration(ctx, profileName)
+	}
+	if profileCfg != nil && profileCfg.Dataset != "" {
+		return profileCfg.Dataset
+	}
+
+	return "default"
+}
+
 // isOAuthAccessToken reports whether token is an OAuth access token
 // (`dash0_at_` prefix) rather than a static token (`auth_` prefix). This is
 // the sole place that inspects the token's prefix; the Dash0 client trusts
@@ -352,6 +407,8 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
+	defaultDataset := resolveDataset(ctx, &cfg, auth.profileCfg)
+
 	ctx = tflog.SetField(ctx, "dash0_url", auth.url)
 	ctx = tflog.SetField(ctx, "dash0_auth_token", auth.token)
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "dash0_auth_token")
@@ -384,7 +441,7 @@ func (p *dash0Provider) Configure(ctx context.Context, req provider.ConfigureReq
 	}
 
 	resp.DataSourceData = dash0Client
-	resp.ResourceData = dash0Client
+	resp.ResourceData = resourceProviderData{client: dash0Client, defaultDataset: defaultDataset}
 	resp.ActionData = dash0Client
 
 	tflog.Info(ctx, "Configured Dash0 client", map[string]any{"success": true})

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	dash0Profiles "github.com/dash0hq/dash0-api-client-go/profiles"
 )
 
 // profilesFixture is a small set of profiles used by tests that exercise the
@@ -62,28 +64,38 @@ func setupCLIConfigDir(t *testing.T, activeProfile, profilesJSON string) string 
 	return dir
 }
 
-// clearCredentialEnv blanks out every env var that resolveAuthInfo reads, and
-// points DASH0_CONFIG_DIR at a non-existent path so the test never picks up
-// the developer's real ~/.dash0. Individual tests can override the config dir.
+// clearCredentialEnv blanks out every env var that resolveAuthInfo and
+// resolveDataset read, and points DASH0_CONFIG_DIR at a non-existent path so
+// the test never picks up the developer's real ~/.dash0. Individual tests can
+// override the config dir.
 func clearCredentialEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("DASH0_API_URL", "")
 	t.Setenv("DASH0_URL", "")
 	t.Setenv("DASH0_AUTH_TOKEN", "")
 	t.Setenv("DASH0_OTLP_URL", "")
+	t.Setenv("DASH0_DATASET", "")
 	t.Setenv("DASH0_CONFIG_DIR", filepath.Join(t.TempDir(), "no-config-here"))
 }
 
 // providerTestConfig builds a tfsdk.Config for provider tests. Pass nil for
-// any value to leave it unset (null). The OTLP URL is left unset; use
-// providerTestConfigWithOtlpURL when it matters.
+// any value to leave it unset (null). The OTLP URL and dataset are left
+// unset; use providerTestConfigWithOtlpURL or providerTestConfigFull when
+// they matter.
 func providerTestConfig(url, authToken, profile *string, maxRetries *int64) tfsdk.Config {
 	return providerTestConfigWithOtlpURL(url, authToken, profile, nil, maxRetries)
 }
 
 // providerTestConfigWithOtlpURL builds a tfsdk.Config including the otlp_url
-// attribute. Pass nil for any value to leave it unset (null).
+// attribute. Pass nil for any value to leave it unset (null). The dataset
+// attribute is left unset; use providerTestConfigFull when it matters.
 func providerTestConfigWithOtlpURL(url, authToken, profile, otlpURL *string, maxRetries *int64) tfsdk.Config {
+	return providerTestConfigFull(url, authToken, profile, otlpURL, nil, maxRetries)
+}
+
+// providerTestConfigFull builds a tfsdk.Config with every provider attribute
+// exposed for tests. Pass nil for any value to leave it unset (null).
+func providerTestConfigFull(url, authToken, profile, otlpURL, dataset *string, maxRetries *int64) tfsdk.Config {
 	stringVal := func(p *string) tftypes.Value {
 		if p == nil {
 			return tftypes.NewValue(tftypes.String, nil)
@@ -103,6 +115,7 @@ func providerTestConfigWithOtlpURL(url, authToken, profile, otlpURL *string, max
 				"auth_token":  tftypes.String,
 				"otlp_url":    tftypes.String,
 				"profile":     tftypes.String,
+				"dataset":     tftypes.String,
 				"max_retries": tftypes.Number,
 			},
 		}, map[string]tftypes.Value{
@@ -110,6 +123,7 @@ func providerTestConfigWithOtlpURL(url, authToken, profile, otlpURL *string, max
 			"auth_token":  stringVal(authToken),
 			"otlp_url":    stringVal(otlpURL),
 			"profile":     stringVal(profile),
+			"dataset":     stringVal(dataset),
 			"max_retries": numberVal(maxRetries),
 		}),
 		Schema: providerSchema(),
@@ -136,7 +150,7 @@ func TestDash0Provider_Schema(t *testing.T) {
 	assert.NotNil(t, resp.Schema)
 	assert.Contains(t, resp.Schema.Description, "observability platform")
 
-	for _, name := range []string{"url", "auth_token", "profile", "max_retries"} {
+	for _, name := range []string{"url", "auth_token", "profile", "dataset", "max_retries"} {
 		assert.Contains(t, resp.Schema.Attributes, name)
 	}
 
@@ -669,4 +683,131 @@ func TestDash0Provider_Configure_OAuthProfile(t *testing.T) {
 
 	assert.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
 	assert.NotNil(t, resp.ResourceData)
+}
+
+// TestResolveDataset_Precedence exercises resolveDataset directly, covering
+// the precedence chain documented on the function: DASH0_DATASET env var >
+// `dataset` attribute > CLI profile dataset > "default".
+func TestResolveDataset_Precedence(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("attribute is used when nothing else is set", func(t *testing.T) {
+		clearCredentialEnv(t)
+		cfg := &providerConfigModel{Dataset: types.StringValue("from-attribute")}
+		assert.Equal(t, "from-attribute", resolveDataset(ctx, cfg, nil))
+	})
+
+	t.Run("env var wins over attribute", func(t *testing.T) {
+		clearCredentialEnv(t)
+		t.Setenv("DASH0_DATASET", "from-env")
+		cfg := &providerConfigModel{Dataset: types.StringValue("from-attribute")}
+		assert.Equal(t, "from-env", resolveDataset(ctx, cfg, nil))
+	})
+
+	t.Run("already-loaded profile supplies the dataset when attribute and env are omitted", func(t *testing.T) {
+		clearCredentialEnv(t)
+		cfg := &providerConfigModel{}
+		profileCfg := &dash0Profiles.Configuration{Dataset: "from-profile"}
+		assert.Equal(t, "from-profile", resolveDataset(ctx, cfg, profileCfg))
+	})
+
+	t.Run("loads the profile itself when resolveAuthInfo never consulted one", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "test1", `{
+  "profiles": [
+    {
+      "name": "test1",
+      "configuration": {
+        "apiUrl": "https://api.example.com",
+        "authToken": "auth_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "dataset": "profile-dataset"
+      }
+    }
+  ]
+}`)
+		cfg := &providerConfigModel{}
+		assert.Equal(t, "profile-dataset", resolveDataset(ctx, cfg, nil))
+	})
+
+	t.Run("falls back to default when nothing resolves", func(t *testing.T) {
+		clearCredentialEnv(t)
+		cfg := &providerConfigModel{}
+		assert.Equal(t, "default", resolveDataset(ctx, cfg, nil))
+	})
+
+	t.Run("an unloadable profile is ignored, falling back to default", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "test1", `{"profiles": [{not valid json}]}`)
+		cfg := &providerConfigModel{}
+		assert.Equal(t, "default", resolveDataset(ctx, cfg, nil))
+	})
+}
+
+// TestDash0Provider_Configure_DefaultDataset verifies that Configure resolves
+// the provider-level default dataset and threads it through resp.ResourceData
+// for resources to inherit.
+func TestDash0Provider_Configure_DefaultDataset(t *testing.T) {
+	t.Run("profile has a dataset, provider config omits it", func(t *testing.T) {
+		clearCredentialEnv(t)
+		setupCLIConfigDir(t, "test1", `{
+  "profiles": [
+    {
+      "name": "test1",
+      "configuration": {
+        "apiUrl": "https://api.us-west-2.aws.dash0.com",
+        "authToken": "auth_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "dataset": "profile-dataset"
+      }
+    }
+  ]
+}`)
+
+		p := &dash0Provider{}
+		req := provider.ConfigureRequest{Config: providerTestConfig(nil, nil, nil, nil)}
+		resp := &provider.ConfigureResponse{}
+		p.Configure(context.Background(), req, resp)
+
+		require.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
+		data, ok := resp.ResourceData.(resourceProviderData)
+		require.True(t, ok, "resp.ResourceData should be a resourceProviderData, got %T", resp.ResourceData)
+		assert.Equal(t, "profile-dataset", data.defaultDataset)
+	})
+
+	t.Run("dataset attribute is honored", func(t *testing.T) {
+		clearCredentialEnv(t)
+
+		p := &dash0Provider{}
+		req := provider.ConfigureRequest{
+			Config: providerTestConfigFull(
+				strPtr("https://api.attr.com"),
+				strPtr("auth_attr_token"),
+				nil, nil,
+				strPtr("attr-dataset"),
+				nil,
+			),
+		}
+		resp := &provider.ConfigureResponse{}
+		p.Configure(context.Background(), req, resp)
+
+		require.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
+		data, ok := resp.ResourceData.(resourceProviderData)
+		require.True(t, ok, "resp.ResourceData should be a resourceProviderData, got %T", resp.ResourceData)
+		assert.Equal(t, "attr-dataset", data.defaultDataset)
+	})
+
+	t.Run("falls back to default when nothing resolves", func(t *testing.T) {
+		clearCredentialEnv(t)
+
+		p := &dash0Provider{}
+		req := provider.ConfigureRequest{
+			Config: providerTestConfig(strPtr("https://api.attr.com"), strPtr("auth_attr_token"), nil, nil),
+		}
+		resp := &provider.ConfigureResponse{}
+		p.Configure(context.Background(), req, resp)
+
+		require.False(t, resp.Diagnostics.HasError(), "diagnostics: %v", resp.Diagnostics.Errors())
+		data, ok := resp.ResourceData.(resourceProviderData)
+		require.True(t, ok, "resp.ResourceData should be a resourceProviderData, got %T", resp.ResourceData)
+		assert.Equal(t, "default", data.defaultDataset)
+	})
 }

--- a/internal/provider/recording_rule_resource.go
+++ b/internal/provider/recording_rule_resource.go
@@ -37,6 +37,9 @@ func NewRecordingRuleResource() resource.Resource {
 // RecordingRuleResource is the resource implementation.
 type RecordingRuleResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // recordingRuleModel is the Terraform state model for a recording rule resource.
@@ -53,16 +56,17 @@ func (r *RecordingRuleResource) Configure(_ context.Context, req resource.Config
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *RecordingRuleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -89,10 +93,12 @@ func (r *RecordingRuleResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the recording rule belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"recording_rule_yaml": schema.StringAttribute{
@@ -132,6 +138,9 @@ func (r *RecordingRuleResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var recordingRuleYaml interface{}

--- a/internal/provider/recording_rule_resource.go
+++ b/internal/provider/recording_rule_resource.go
@@ -97,8 +97,8 @@ func (r *RecordingRuleResource) Schema(_ context.Context, _ resource.SchemaReque
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"recording_rule_yaml": schema.StringAttribute{

--- a/internal/provider/recording_rule_resource_test.go
+++ b/internal/provider/recording_rule_resource_test.go
@@ -80,10 +80,11 @@ func TestRecordingRuleResource_Schema(t *testing.T) {
 	assert.True(t, originAttr.IsComputed())
 	assert.False(t, originAttr.IsRequired())
 
-	// Verify dataset is required
+	// Verify dataset is optional, inherited from the provider default when omitted
 	datasetAttr := resp.Schema.Attributes["dataset"]
-	assert.True(t, datasetAttr.IsRequired())
-	assert.False(t, datasetAttr.IsComputed())
+	assert.False(t, datasetAttr.IsRequired())
+	assert.True(t, datasetAttr.IsOptional())
+	assert.True(t, datasetAttr.IsComputed())
 
 	// Verify recording_rule_yaml is required
 	yamlAttr := resp.Schema.Attributes["recording_rule_yaml"]
@@ -100,7 +101,7 @@ func TestRecordingRuleResource_Configure(t *testing.T) {
 	}{
 		{
 			name:         "valid client interface",
-			providerData: &MockClient{},
+			providerData: resourceProviderData{client: &MockClient{}, defaultDataset: "default"},
 			expectError:  false,
 		},
 		{

--- a/internal/provider/spam_filter_resource.go
+++ b/internal/provider/spam_filter_resource.go
@@ -37,6 +37,9 @@ func NewSpamFilterResource() resource.Resource {
 // SpamFilterResource is the resource implementation.
 type SpamFilterResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // spamFilterModel is the Terraform state model for a spam filter resource.
@@ -53,16 +56,17 @@ func (r *SpamFilterResource) Configure(_ context.Context, req resource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *SpamFilterResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -92,10 +96,12 @@ func (r *SpamFilterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the spam filter belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"spam_filter_yaml": schema.StringAttribute{
@@ -139,6 +145,9 @@ func (r *SpamFilterResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var spamFilterYaml interface{}

--- a/internal/provider/spam_filter_resource.go
+++ b/internal/provider/spam_filter_resource.go
@@ -100,8 +100,8 @@ func (r *SpamFilterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"spam_filter_yaml": schema.StringAttribute{

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -37,6 +37,9 @@ func NewSyntheticCheckResource() resource.Resource {
 // SyntheticCheckResource is the resource implementation.
 type SyntheticCheckResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // syntheticCheckModel is the Terraform state model for a synthetic check resource.
@@ -54,16 +57,17 @@ func (r *SyntheticCheckResource) Configure(_ context.Context, req resource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *SyntheticCheckResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -89,10 +93,12 @@ func (r *SyntheticCheckResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the synthetic check belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"synthetic_check_yaml": schema.StringAttribute{
@@ -141,6 +147,9 @@ func (r *SyntheticCheckResource) Create(ctx context.Context, req resource.Create
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var checkYaml interface{}

--- a/internal/provider/synthetic_check_resource.go
+++ b/internal/provider/synthetic_check_resource.go
@@ -97,8 +97,8 @@ func (r *SyntheticCheckResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"synthetic_check_yaml": schema.StringAttribute{

--- a/internal/provider/synthetic_check_resource_test.go
+++ b/internal/provider/synthetic_check_resource_test.go
@@ -53,9 +53,11 @@ func TestSyntheticCheckResource_Schema(t *testing.T) {
 	originAttr := attrs["origin"].(schema.StringAttribute)
 	assert.True(t, originAttr.Computed)
 
-	// Check dataset is required
+	// Check dataset is optional, inherited from the provider default when omitted
 	datasetAttr := attrs["dataset"].(schema.StringAttribute)
-	assert.True(t, datasetAttr.Required)
+	assert.False(t, datasetAttr.Required)
+	assert.True(t, datasetAttr.Optional)
+	assert.True(t, datasetAttr.Computed)
 
 	// Check synthetic_check_yaml is required
 	checkYamlAttr := attrs["synthetic_check_yaml"].(schema.StringAttribute)

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -118,16 +118,16 @@ func (r *TeamResource) Configure(_ context.Context, req resource.ConfigureReques
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
 }
 
 func (r *TeamResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -87,7 +87,7 @@ func TestTeamResource_Configure(t *testing.T) {
 		expectError  bool
 		errorMessage string
 	}{
-		{name: "valid client interface", providerData: &MockClient{}, expectError: false},
+		{name: "valid client interface", providerData: resourceProviderData{client: &MockClient{}}, expectError: false},
 		{name: "nil provider data", providerData: nil, expectError: false},
 		{
 			name:         "invalid provider data type",

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -37,6 +37,9 @@ func NewViewResource() resource.Resource {
 // ViewResource is the resource implementation.
 type ViewResource struct {
 	client client.Client
+	// defaultDataset is the provider-level default dataset, inherited by this
+	// resource's `dataset` attribute when it is omitted from configuration.
+	defaultDataset string
 }
 
 // viewModel is the Terraform state model for a view resource.
@@ -54,16 +57,17 @@ func (r *ViewResource) Configure(_ context.Context, req resource.ConfigureReques
 		return
 	}
 
-	client, ok := req.ProviderData.(client.Client)
+	data, ok := req.ProviderData.(resourceProviderData)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected provider.resourceProviderData, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = data.client
+	r.defaultDataset = data.defaultDataset
 }
 
 func (r *ViewResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -89,10 +93,12 @@ func (r *ViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"dataset": schema.StringAttribute{
-				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. Changing this value forces the resource to be recreated.",
-				Required:    true,
+				Description: "The identifier of the [Dash0 dataset](https://dash0.com/docs/dash0/miscellaneous/glossary/datasets) that the view belongs to. Provide the dataset's identifier, which is immutable, not the 'name'. Datasets are used to separate observability data within a Dash0 organization. If omitted, the provider-level `dataset` default is used (see the provider's `dataset` attribute). Changing this value forces the resource to be recreated.",
+				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"view_yaml": schema.StringAttribute{
@@ -141,6 +147,9 @@ func (r *ViewResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	model.Origin = types.StringValue("tf_" + uuid.New().String())
+	if model.Dataset.IsNull() || model.Dataset.IsUnknown() {
+		model.Dataset = types.StringValue(r.defaultDataset)
+	}
 
 	// Validate YAML format
 	var viewYaml interface{}

--- a/internal/provider/view_resource.go
+++ b/internal/provider/view_resource.go
@@ -97,8 +97,8 @@ func (r *ViewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"view_yaml": schema.StringAttribute{

--- a/internal/provider/view_resource_test.go
+++ b/internal/provider/view_resource_test.go
@@ -43,7 +43,8 @@ func TestViewResource_Schema(t *testing.T) {
 
 	// Check specific attribute properties
 	assert.True(t, resp.Schema.Attributes["origin"].(schema.StringAttribute).Computed)
-	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Required)
+	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Optional)
+	assert.True(t, resp.Schema.Attributes["dataset"].(schema.StringAttribute).Computed)
 	assert.True(t, resp.Schema.Attributes["view_yaml"].(schema.StringAttribute).Required)
 	assert.True(t, resp.Schema.Attributes["url"].(schema.StringAttribute).Computed)
 }
@@ -60,8 +61,9 @@ func TestViewResource_Configure(t *testing.T) {
 
 	// Test with valid provider data
 	resp = &resource.ConfigureResponse{}
-	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, resp)
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: resourceProviderData{client: client, defaultDataset: "default"}}, resp)
 	assert.Equal(t, client, r.client)
+	assert.Equal(t, "default", r.defaultDataset)
 	assert.False(t, resp.Diagnostics.HasError())
 
 	// Test with invalid provider data

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -46,6 +46,7 @@ The following environment variables are supported:
 | `DASH0_AUTH_TOKEN` | Yes | The API auth token for Dash0. Must start with `auth_` or `dash0_at_`. Overrides the `auth_token` provider attribute. | — |
 | `DASH0_OTLP_URL` | No | The base URL of the Dash0 OTLP/HTTP ingress endpoint (e.g. `https://ingress.us-west-2.aws.dash0.com`). Find yours on the [OTLP endpoint settings page](https://app.dash0.com/goto/settings/endpoints?endpoint_type=otlp_http). Overrides the `otlp_url` provider attribute. Only needed by the `dash0_log_event` and `dash0_deployment_event` actions. | — |
 | `DASH0_CONFIG_DIR` | No | Directory containing the dash0 CLI configuration files (`activeProfile`, `profiles.json`). Used when loading credentials from a CLI profile. | `~/.dash0` |
+| `DASH0_DATASET` | No | Default dataset used by dataset-scoped resources that omit their own `dataset` attribute. Overrides the `dataset` provider attribute. | `"default"` |
 | `DASH0_MAX_RETRIES` | No | Maximum number of retries for failed API requests (0–5). Overrides the `max_retries` provider attribute. | `3` |
 
 ### Option 2: Provider Configuration
@@ -90,6 +91,20 @@ If you see this error, upgrade the provider to the latest version.
 
 **Note:** The `dash0_log_event` and `dash0_deployment_event` actions require a static token (`auth_` prefix, from [Dash0 Settings > Auth Tokens](https://app.dash0.com/goto/settings/auth-tokens)) — supplied via `auth_token`, `DASH0_AUTH_TOKEN`, or a non-OAuth profile.
 The Dash0 OTLP/HTTP ingress endpoint those actions send to does not accept OAuth access tokens, even though the Dash0 API does, so an OAuth-enabled profile fails those actions with an actionable error.
+
+## Default dataset
+
+Dataset-scoped resources (`dash0_dashboard`, `dash0_check_rule`, `dash0_recording_rule`, `dash0_spam_filter`, `dash0_synthetic_check`, `dash0_view`) accept an optional `dataset` attribute.
+When a resource omits it, the resource inherits a provider-level default resolved in this order:
+
+1. The `DASH0_DATASET` environment variable.
+2. The `dataset` provider attribute.
+3. The dataset configured on the resolved dash0 CLI profile.
+4. `"default"`.
+
+{{ tffile "examples/provider/provider_with_dataset.tf" }}
+
+~> **Note:** A resource's inherited dataset is resolved once, at create time, and pinned into state. Changing the provider-level `dataset` afterward does not move existing resources. To move a resource, set its own `dataset` attribute, which forces the resource to be recreated as it always does.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Adds an optional provider-level `dataset` attribute, resolved via `DASH0_DATASET` env var > `dataset` attribute > dash0 CLI profile dataset > `"default"` (mirrors the existing credential-resolution precedence). Relaxes the per-resource `dataset` attribute on `dash0_dashboard`, `dash0_check_rule`, `dash0_recording_rule`, `dash0_spam_filter`, `dash0_synthetic_check`, and `dash0_view` from `Required` to `Optional`+`Computed` with `UseStateForUnknown()`. An omitted `dataset` resolves the provider default once at create time and is pinned into state, so changing the provider-level default afterward never moves existing resources — `RequiresReplace()` still fires only when a resource's own `dataset` is edited explicitly.

Fixes #158.