### PR TITLE
fix(spam_filters): serialize dataset writes to avoid unretried 409 conflicts

### DIFF
--- a/.chloggen/repro_spam-filter-concurrent-409.yaml
+++ b/.chloggen/repro_spam-filter-concurrent-409.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: spam_filters
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix `dash0_spam_filter` create/update/delete calls to the same dataset failing with an unretried 409 dataset version conflict when a single `terraform apply` changes more than one spam filter at once."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [165]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Terraform's default parallelism issues concurrent Create/Update/Delete calls for spam filters in the same
+  dataset, racing the dataset's optimistic-concurrency version. The provider now serializes spam filter writes
+  per dataset so the race never reaches the API, instead of surfacing the conflict as an unretried error.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/repro_spam-filter-concurrent-409.yaml
+++ b/.chloggen/repro_spam-filter-concurrent-409.yaml
@@ -19,6 +19,9 @@ subtext: |
   Terraform's default parallelism issues concurrent Create/Update/Delete calls for spam filters in the same
   dataset, racing the dataset's optimistic-concurrency version. The provider now serializes spam filter writes
   per dataset so the race never reaches the API, instead of surfacing the conflict as an unretried error.
+  The serialization covers every provider instance in a run, so aliased provider blocks writing the same
+  dataset are serialized against each other too. Writers outside the Terraform process — a concurrent
+  apply, the Dash0 web app, the CLI, or the Operator — are still able to race the dataset version.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with "chore" or use the "Skip Changelog" label.

--- a/internal/provider/client/dash0.go
+++ b/internal/provider/client/dash0.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"sync"
 
 	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
@@ -30,10 +29,6 @@ type dash0Client struct {
 	// version is the provider version. It is used as the OpenTelemetry
 	// instrumentation scope version on emitted telemetry.
 	version string
-	// spamFilterDatasetLocks holds one *sync.Mutex per dataset (map[string]*sync.Mutex),
-	// used to serialize spam filter Create/Update/Delete calls against the same
-	// dataset. See lockSpamFilterDataset in spam_filter.go for why.
-	spamFilterDatasetLocks sync.Map
 }
 
 // NewDash0Client creates a new Dash0 API client backed by the shared library.

--- a/internal/provider/client/dash0.go
+++ b/internal/provider/client/dash0.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"sync"
 
 	dash0 "github.com/dash0hq/dash0-api-client-go"
 )
@@ -29,6 +30,10 @@ type dash0Client struct {
 	// version is the provider version. It is used as the OpenTelemetry
 	// instrumentation scope version on emitted telemetry.
 	version string
+	// spamFilterDatasetLocks holds one *sync.Mutex per dataset (map[string]*sync.Mutex),
+	// used to serialize spam filter Create/Update/Delete calls against the same
+	// dataset. See lockSpamFilterDataset in spam_filter.go for why.
+	spamFilterDatasetLocks sync.Map
 }
 
 // NewDash0Client creates a new Dash0 API client backed by the shared library.

--- a/internal/provider/client/dataset_lock.go
+++ b/internal/provider/client/dataset_lock.go
@@ -1,0 +1,53 @@
+package client
+
+import "sync"
+
+// datasetLocks holds one *sync.Mutex per dataset name, serializing writes that
+// contend for the same dataset's version. It is deliberately package-level
+// rather than a field on dash0Client: Configure builds a fresh dash0Client for
+// every provider instance (see NewDash0Client), so two aliased provider blocks
+// pointing at the same dataset would otherwise take different mutexes and race
+// each other exactly as unaliased resources did before this lock existed.
+//
+// The map grows by one entry per distinct dataset name written during a run.
+// A provider process is scoped to a single plan or apply over a bounded set of
+// datasets, so there is nothing to evict.
+var datasetLocks sync.Map
+
+// lockDataset acquires the write lock for the given dataset and returns a
+// function that releases it.
+//
+// The Dash0 API guards each dataset with an optimistic-concurrency "dataset
+// version". Asset kinds that share one document per dataset — spam filters
+// today — bump that version on every write, so concurrent writers race it and
+// all but one come back with a 409 that nothing in the stack retries: neither
+// the api-client-go transport (which retries only 429 and 5xx) nor the
+// provider. Terraform's default parallelism of 10 makes that race the norm
+// rather than the exception whenever a single apply touches more than one such
+// asset in the same dataset. Serializing the writes prevents the race instead
+// of reacting to it after the fact.
+//
+// The key is the dataset name alone, which can over-serialize: two provider
+// blocks authenticated against different Dash0 organizations that both write a
+// dataset of the same name (`default` exists in every organization) share a
+// mutex even though they contend for different dataset versions. That is a
+// deliberate trade: dash0Client carries no organization identity to key on, the
+// affected write volume is tiny, and the cost of the alternative — deriving a
+// key that turns out not to identify a dataset uniquely — is the silent return
+// of the very 409 this prevents.
+//
+// Callers must invoke the returned function, conventionally via defer:
+//
+//	unlock := lockDataset(dataset)
+//	defer unlock()
+//
+// This lock is in-process only. It cannot serialize against concurrent
+// `terraform apply` runs, the Dash0 web app, the CLI, or the Operator writing
+// the same dataset; surviving those needs a retry on 409 (dash0.IsConflict) and
+// is tracked separately.
+func lockDataset(dataset string) func() {
+	value, _ := datasetLocks.LoadOrStore(dataset, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/provider/client/dataset_lock_test.go
+++ b/internal/provider/client/dataset_lock_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLockDataset_SeparateClientsSameDatasetAreSerialized is the regression
+// test for the hole in the first version of this fix, where the lock registry
+// was a field on dash0Client. Configure builds a fresh dash0Client per provider
+// instance, so two aliased provider blocks pointing at the same account and
+// dataset took different mutexes for the same dataset name and raced the
+// dataset version anyway — the 409 the lock exists to prevent.
+//
+// Two distinct clients writing the same dataset must therefore never overlap in
+// flight, exactly as two resources on one client must not.
+func TestLockDataset_SeparateClientsSameDatasetAreSerialized(t *testing.T) {
+	const dataset = "two-clients-same-dataset"
+
+	// One fake shared by both clients, so in-flight counts observe the writes
+	// of both — the fake stands in for the single dataset version on the server
+	// that both provider aliases contend for.
+	var attempts, inFlight, maxInFlight int32
+	fake := trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)
+	clientA := &dash0Client{inner: fake}
+	clientB := &dash0Client{inner: fake}
+
+	var wg sync.WaitGroup
+	var release sync.WaitGroup
+	release.Add(1)
+
+	errs := make([]error, 2)
+	for i, c := range []*dash0Client{clientA, clientB} {
+		wg.Add(1)
+		go func(i int, c *dash0Client) {
+			defer wg.Done()
+			release.Wait() // start both writes at the same instant
+			errs[i] = c.UpdateSpamFilter(context.Background(), "tf_filter", minimalV1Alpha1SpamFilterJSON, dataset)
+		}(i, c)
+	}
+	release.Done()
+	wg.Wait()
+
+	require.EqualValues(t, 2, attempts, "both clients' writes should have reached the API")
+	assert.EqualValues(t, 1, maxInFlight,
+		"writes from separate clients to the same dataset must be serialized: two provider aliases contend for one dataset version")
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+// TestLockDataset_SeparateClientsDifferentDatasetsAreNotSerialized keeps the
+// registry honest in the other direction. Without it, making the lock a single
+// global mutex would satisfy every other test in this package while serializing
+// writes that never contended in the first place.
+func TestLockDataset_SeparateClientsDifferentDatasetsAreNotSerialized(t *testing.T) {
+	var attempts, inFlight, maxInFlight int32
+	fake := trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)
+	clients := []*dash0Client{{inner: fake}, {inner: fake}}
+	datasets := []string{"two-clients-dataset-a", "two-clients-dataset-b"}
+
+	var wg sync.WaitGroup
+	var release sync.WaitGroup
+	release.Add(1)
+
+	for i := range clients {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			release.Wait()
+			assert.NoError(t, clients[i].UpdateSpamFilter(
+				context.Background(), "tf_filter", minimalV1Alpha1SpamFilterJSON, datasets[i]))
+		}(i)
+	}
+	release.Done()
+	wg.Wait()
+
+	require.EqualValues(t, 2, attempts, "both writes should have reached the API")
+	assert.EqualValues(t, 2, maxInFlight,
+		"the lock is keyed per dataset, so writes to unrelated datasets must not serialize even across clients")
+}
+
+// TestLockDataset_SameDatasetNameYieldsTheSameMutex covers the registry itself,
+// independent of any asset kind: repeated calls for one dataset name must hand
+// out the same mutex, and the returned function must release it.
+func TestLockDataset_SameDatasetNameYieldsTheSameMutex(t *testing.T) {
+	const dataset = "lock-registry-identity"
+
+	unlock := lockDataset(dataset)
+
+	acquired := make(chan struct{})
+	go func() {
+		defer close(acquired)
+		lockDataset(dataset)()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("a second lockDataset call for the same dataset acquired the mutex while it was held")
+	default:
+	}
+
+	unlock()
+
+	select {
+	case <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the function returned by lockDataset did not release the mutex")
+	}
+}
+
+// TestLockDataset_DistinctDatasetNamesYieldDistinctMutexes is the counterpart:
+// holding one dataset's lock must not block another's.
+func TestLockDataset_DistinctDatasetNamesYieldDistinctMutexes(t *testing.T) {
+	unlock := lockDataset("lock-registry-distinct-a")
+	defer unlock()
+
+	acquired := make(chan struct{})
+	go func() {
+		defer close(acquired)
+		lockDataset("lock-registry-distinct-b")()
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("holding one dataset's lock blocked an unrelated dataset's lock")
+	}
+}

--- a/internal/provider/client/spam_filter.go
+++ b/internal/provider/client/spam_filter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -47,8 +46,8 @@ func (c *dash0Client) upsertSpamFilter(ctx context.Context, origin, filterJSON, 
 		return fmt.Errorf("error parsing spam filter JSON: %w", err)
 	}
 
-	// Serialize writes to this dataset — see lockSpamFilterDataset for why.
-	unlock := c.lockSpamFilterDataset(dataset)
+	// Serialize writes to this dataset — see lockDataset for why.
+	unlock := lockDataset(dataset)
 	defer unlock()
 
 	if isV1Alpha2 {
@@ -109,8 +108,8 @@ func (c *dash0Client) GetSpamFilter(ctx context.Context, origin string, dataset 
 }
 
 func (c *dash0Client) DeleteSpamFilter(ctx context.Context, origin string, dataset string) error {
-	// Serialize writes to this dataset — see lockSpamFilterDataset for why.
-	unlock := c.lockSpamFilterDataset(dataset)
+	// Serialize writes to this dataset — see lockDataset for why.
+	unlock := lockDataset(dataset)
 	defer unlock()
 
 	err := c.inner.DeleteSpamFilter(ctx, origin, &dataset)
@@ -120,27 +119,6 @@ func (c *dash0Client) DeleteSpamFilter(ctx context.Context, origin string, datas
 
 	tflog.Debug(ctx, fmt.Sprintf("Spam filter deleted with origin: %s", origin))
 	return nil
-}
-
-// lockSpamFilterDataset serializes spam filter Create/Update/Delete calls
-// against the given dataset and returns a function that releases the lock.
-//
-// The Dash0 API guards each dataset with an optimistic-concurrency "dataset
-// version". When a single `terraform apply` touches more than one spam
-// filter in the same dataset, Terraform's default parallelism issues those
-// Create/Update/Delete calls concurrently, and all but one of them race the
-// dataset version and come back as a 409 that nothing in the stack retries.
-// Serializing writes per dataset on the client instance (which is reused
-// across resource instances for a given provider configuration, see
-// NewDash0Client) prevents the race instead of retrying after the fact.
-//
-// The lock is keyed by dataset only, so writes to unrelated datasets are
-// never serialized against each other.
-func (c *dash0Client) lockSpamFilterDataset(dataset string) func() {
-	value, _ := c.spamFilterDatasetLocks.LoadOrStore(dataset, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
-	return mu.Unlock
 }
 
 // ResolveSpamFilter looks up the server-assigned id of the spam filter with

--- a/internal/provider/client/spam_filter.go
+++ b/internal/provider/client/spam_filter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -45,6 +46,10 @@ func (c *dash0Client) upsertSpamFilter(ctx context.Context, origin, filterJSON, 
 	if err != nil {
 		return fmt.Errorf("error parsing spam filter JSON: %w", err)
 	}
+
+	// Serialize writes to this dataset — see lockSpamFilterDataset for why.
+	unlock := c.lockSpamFilterDataset(dataset)
+	defer unlock()
 
 	if isV1Alpha2 {
 		filter, err := unmarshalSpamFilterV1Alpha2(filterJSON)
@@ -104,6 +109,10 @@ func (c *dash0Client) GetSpamFilter(ctx context.Context, origin string, dataset 
 }
 
 func (c *dash0Client) DeleteSpamFilter(ctx context.Context, origin string, dataset string) error {
+	// Serialize writes to this dataset — see lockSpamFilterDataset for why.
+	unlock := c.lockSpamFilterDataset(dataset)
+	defer unlock()
+
 	err := c.inner.DeleteSpamFilter(ctx, origin, &dataset)
 	if err != nil {
 		return err
@@ -111,6 +120,27 @@ func (c *dash0Client) DeleteSpamFilter(ctx context.Context, origin string, datas
 
 	tflog.Debug(ctx, fmt.Sprintf("Spam filter deleted with origin: %s", origin))
 	return nil
+}
+
+// lockSpamFilterDataset serializes spam filter Create/Update/Delete calls
+// against the given dataset and returns a function that releases the lock.
+//
+// The Dash0 API guards each dataset with an optimistic-concurrency "dataset
+// version". When a single `terraform apply` touches more than one spam
+// filter in the same dataset, Terraform's default parallelism issues those
+// Create/Update/Delete calls concurrently, and all but one of them race the
+// dataset version and come back as a 409 that nothing in the stack retries.
+// Serializing writes per dataset on the client instance (which is reused
+// across resource instances for a given provider configuration, see
+// NewDash0Client) prevents the race instead of retrying after the fact.
+//
+// The lock is keyed by dataset only, so writes to unrelated datasets are
+// never serialized against each other.
+func (c *dash0Client) lockSpamFilterDataset(dataset string) func() {
+	value, _ := c.spamFilterDatasetLocks.LoadOrStore(dataset, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 // ResolveSpamFilter looks up the server-assigned id of the spam filter with

--- a/internal/provider/client/spam_filter_test.go
+++ b/internal/provider/client/spam_filter_test.go
@@ -66,12 +66,12 @@ func trackingSpamFilterFake(attempts, inFlight, maxInFlight *int32) *dash0test.M
 // losing resource.
 //
 // Rather than retrying after the fact, upsertSpamFilter now serializes
-// Create/Update/Delete calls per dataset (see lockSpamFilterDataset), so the
+// Create/Update/Delete calls per dataset (see lockDataset), so the
 // race never reaches the API in the first place. This test fires two
 // concurrent updates at the same dataset and asserts that the fake API never
 // observes more than one of them in flight at once, and that both succeed.
 func TestUpsertSpamFilter_ConcurrentWritesToSameDatasetAreSerialized(t *testing.T) {
-	const dataset = "shared-dataset"
+	const dataset = "upsert-same-dataset"
 	origins := []string{"tf_filter_a", "tf_filter_b"}
 
 	var attempts, inFlight, maxInFlight int32
@@ -105,6 +105,9 @@ func TestUpsertSpamFilter_ConcurrentWritesToSameDatasetAreSerialized(t *testing.
 // per-dataset lock added to fix the concurrent-409 bug is scoped to a single
 // dataset, not global: concurrent writes to unrelated datasets must still be
 // able to run at the same time.
+//
+// Note that the lock registry is process-wide (see lockDataset), so every test
+// in this package uses dataset names of its own rather than sharing one.
 func TestSpamFilterWrites_DifferentDatasetsAreNotSerialized(t *testing.T) {
 	var attempts, inFlight, maxInFlight int32
 	c := &dash0Client{inner: trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)}
@@ -113,7 +116,7 @@ func TestSpamFilterWrites_DifferentDatasetsAreNotSerialized(t *testing.T) {
 	var release sync.WaitGroup
 	release.Add(1)
 
-	datasets := []string{"dataset-a", "dataset-b"}
+	datasets := []string{"unrelated-dataset-a", "unrelated-dataset-b"}
 	for i, dataset := range datasets {
 		wg.Add(1)
 		go func(i int, dataset string) {
@@ -136,7 +139,7 @@ func TestSpamFilterWrites_DifferentDatasetsAreNotSerialized(t *testing.T) {
 // exactly the kind of concurrent write that raced the dataset version before
 // this fix.
 func TestDeleteSpamFilter_SerializedWithConcurrentUpdateToSameDataset(t *testing.T) {
-	const dataset = "shared-dataset"
+	const dataset = "delete-with-update-same-dataset"
 
 	var attempts, inFlight, maxInFlight int32
 	c := &dash0Client{inner: trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)}

--- a/internal/provider/client/spam_filter_test.go
+++ b/internal/provider/client/spam_filter_test.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dash0 "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-api-client-go/dash0test"
+)
+
+const minimalV1Alpha1SpamFilterJSON = `{
+	"apiVersion": "v1alpha1",
+	"kind": "Dash0SpamFilter",
+	"metadata": {"name": "repro-filter"},
+	"spec": {
+		"filter": [{"key": "body", "value": "spam"}],
+		"contexts": ["log"]
+	}
+}`
+
+// trackingSpamFilterFake returns a dash0test.MockClient whose
+// UpdateSpamFilterFunc and DeleteSpamFilterFunc record how many calls are
+// concurrently "in flight" (i.e. actually executing) at once, tracking the
+// high-water mark in maxInFlight. A short sleep on entry widens the window
+// during which a real race would show up as more than one call in flight at
+// the same time.
+func trackingSpamFilterFake(attempts, inFlight, maxInFlight *int32) *dash0test.MockClient {
+	track := func() {
+		atomic.AddInt32(attempts, 1)
+		n := atomic.AddInt32(inFlight, 1)
+		for {
+			max := atomic.LoadInt32(maxInFlight)
+			if n <= max || atomic.CompareAndSwapInt32(maxInFlight, max, n) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		atomic.AddInt32(inFlight, -1)
+	}
+	return &dash0test.MockClient{
+		UpdateSpamFilterFunc: func(ctx context.Context, originOrID string, filter *dash0.SpamFilter, dataset *string) (*dash0.SpamFilter, error) {
+			track()
+			return filter, nil
+		},
+		DeleteSpamFilterFunc: func(ctx context.Context, originOrID string, dataset *string) error {
+			track()
+			return nil
+		},
+	}
+}
+
+// TestUpsertSpamFilter_ConcurrentWritesToSameDatasetAreSerialized guards
+// against the second bug reported against dash0_spam_filter: when a
+// Terraform apply touches more than one spam filter in the same dataset in a
+// single run, Terraform's default parallelism issues those Create/Update
+// calls concurrently. The real Dash0 API guards each dataset with an
+// optimistic-concurrency "dataset version", so concurrent writers race that
+// version and all but one come back with a 409 "please retry" that nothing
+// in the stack retries — the user has to re-run `terraform apply` once per
+// losing resource.
+//
+// Rather than retrying after the fact, upsertSpamFilter now serializes
+// Create/Update/Delete calls per dataset (see lockSpamFilterDataset), so the
+// race never reaches the API in the first place. This test fires two
+// concurrent updates at the same dataset and asserts that the fake API never
+// observes more than one of them in flight at once, and that both succeed.
+func TestUpsertSpamFilter_ConcurrentWritesToSameDatasetAreSerialized(t *testing.T) {
+	const dataset = "shared-dataset"
+	origins := []string{"tf_filter_a", "tf_filter_b"}
+
+	var attempts, inFlight, maxInFlight int32
+	c := &dash0Client{inner: trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)}
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(origins))
+	var release sync.WaitGroup
+	release.Add(1)
+
+	for i, origin := range origins {
+		wg.Add(1)
+		go func(i int, origin string) {
+			defer wg.Done()
+			release.Wait() // start both upserts at the same instant
+			errs[i] = c.UpdateSpamFilter(context.Background(), origin, minimalV1Alpha1SpamFilterJSON, dataset)
+		}(i, origin)
+	}
+	release.Done()
+	wg.Wait()
+
+	require.EqualValues(t, len(origins), attempts, "both writes should have reached the API")
+	assert.EqualValues(t, 1, maxInFlight,
+		"writes to the same dataset must be serialized so they never overlap in flight, avoiding the dataset-version race entirely")
+	for _, err := range errs {
+		assert.NoError(t, err, "serialized writes should never surface a dataset-version conflict")
+	}
+}
+
+// TestSpamFilterWrites_DifferentDatasetsAreNotSerialized checks that the
+// per-dataset lock added to fix the concurrent-409 bug is scoped to a single
+// dataset, not global: concurrent writes to unrelated datasets must still be
+// able to run at the same time.
+func TestSpamFilterWrites_DifferentDatasetsAreNotSerialized(t *testing.T) {
+	var attempts, inFlight, maxInFlight int32
+	c := &dash0Client{inner: trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)}
+
+	var wg sync.WaitGroup
+	var release sync.WaitGroup
+	release.Add(1)
+
+	datasets := []string{"dataset-a", "dataset-b"}
+	for i, dataset := range datasets {
+		wg.Add(1)
+		go func(i int, dataset string) {
+			defer wg.Done()
+			release.Wait()
+			assert.NoError(t, c.UpdateSpamFilter(context.Background(), "tf_filter", minimalV1Alpha1SpamFilterJSON, dataset))
+		}(i, dataset)
+	}
+	release.Done()
+	wg.Wait()
+
+	require.EqualValues(t, len(datasets), attempts, "both writes should have reached the API")
+	assert.EqualValues(t, len(datasets), maxInFlight,
+		"writes to different datasets should not be serialized against each other")
+}
+
+// TestDeleteSpamFilter_SerializedWithConcurrentUpdateToSameDataset checks
+// that Delete is covered by the same per-dataset lock as Create/Update:
+// deleting one spam filter while updating another in the same dataset is
+// exactly the kind of concurrent write that raced the dataset version before
+// this fix.
+func TestDeleteSpamFilter_SerializedWithConcurrentUpdateToSameDataset(t *testing.T) {
+	const dataset = "shared-dataset"
+
+	var attempts, inFlight, maxInFlight int32
+	c := &dash0Client{inner: trackingSpamFilterFake(&attempts, &inFlight, &maxInFlight)}
+
+	var wg sync.WaitGroup
+	var release sync.WaitGroup
+	release.Add(1)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		release.Wait()
+		assert.NoError(t, c.UpdateSpamFilter(context.Background(), "tf_filter_a", minimalV1Alpha1SpamFilterJSON, dataset))
+	}()
+	go func() {
+		defer wg.Done()
+		release.Wait()
+		assert.NoError(t, c.DeleteSpamFilter(context.Background(), "tf_filter_b", dataset))
+	}()
+	release.Done()
+	wg.Wait()
+
+	require.EqualValues(t, 2, attempts, "both the update and the delete should have reached the API")
+	assert.EqualValues(t, 1, maxInFlight, "delete and update to the same dataset must be serialized against each other")
+}

--- a/test/roundtrip/common.sh
+++ b/test/roundtrip/common.sh
@@ -114,6 +114,15 @@ tf_state_show() {
   (cd "$dir" && TF_CLI_CONFIG_FILE="${dir}/.terraformrc" $TF state show "$address")
 }
 
+# tf_output_json <work_dir> <output_name>
+#
+# Like tf_output, but for outputs that are not plain strings (maps, lists),
+# returned as their raw JSON encoding.
+tf_output_json() {
+  local dir="$1" name="$2"
+  (cd "$dir" && TF_CLI_CONFIG_FILE="${dir}/.terraformrc" $TF output -json "$name" 2>/dev/null)
+}
+
 tf_plan_detailed_exitcode() {
   local dir="$1"
   (cd "$dir" && TF_CLI_CONFIG_FILE="${dir}/.terraformrc" $TF plan -detailed-exitcode -input=false)

--- a/test/roundtrip/run_all.sh
+++ b/test/roundtrip/run_all.sh
@@ -100,6 +100,7 @@ else
     test_notification_channel.sh
     test_spam_filter_v1alpha1.sh
     test_spam_filter_v1alpha2.sh
+    test_spam_filter_concurrent.sh
     test_team.sh
     test_import_check_rule.sh
     test_import_dashboard.sh

--- a/test/roundtrip/test_spam_filter_concurrent.sh
+++ b/test/roundtrip/test_spam_filter_concurrent.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Roundtrip test for concurrent dash0_spam_filter writes to the same dataset.
+#
+# Regression test for https://github.com/dash0hq/terraform-provider-dash0/issues/165:
+# a single `terraform apply`/`tofu apply` that creates or updates more than
+# one dash0_spam_filter in the same dataset used to fail with an unretried
+# "409 dataset version conflict" for all but one resource, because Terraform's
+# default parallelism (up to 10) issues those Create/Update/Delete calls
+# concurrently and the provider raced the dataset's optimistic-concurrency
+# version. The fix serializes spam filter writes per dataset instead of
+# retrying after the fact.
+#
+# This test creates, updates, and destroys several spam filters in the same
+# dataset via a single `for_each` resource, each step in exactly one
+# tofu apply/destroy, and asserts that a single run converges all of them —
+# the symptom of the bug was needing to re-run once per losing resource.
+#
+# Steps:
+#   1. Create N spam filters in one dataset via a single tofu apply
+#   2. Verify all N exist via dash0 CLI
+#   3. Update all N filters and re-apply in a single tofu apply
+#   4. Re-apply without changes (idempotency)
+#   5. Destroy all N filters via a single tofu destroy
+#   6. Verify all N are gone
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Comfortably above Terraform's default parallelism of 10 so a single apply
+# is guaranteed to issue genuinely concurrent Create/Update/Delete calls
+# against the same dataset, not just a small batch that could complete
+# serially by chance.
+FILTER_COUNT=12
+
+info "=== Roundtrip test: dash0_spam_filter concurrent writes to one dataset ==="
+info "Working directory: ${WORK_DIR}"
+info "Dataset: ${DATASET}"
+info "Filter count: ${FILTER_COUNT}"
+
+# ---------------------------------------------------------------------------
+# Step 0: Write provider configuration
+# ---------------------------------------------------------------------------
+write_provider_tf "$WORK_DIR"
+
+# ---------------------------------------------------------------------------
+# Step 1: Create N spam filters in one dataset via a single apply
+# ---------------------------------------------------------------------------
+info "Step 1: Creating ${FILTER_COUNT} spam filters in one dataset via a single tofu apply..."
+
+python3 - "$WORK_DIR" "$FILTER_COUNT" <<'PYEOF'
+import sys
+
+work_dir, count = sys.argv[1], int(sys.argv[2])
+
+keys = ", ".join(f'"filter-{i:02d}" = "concurrent-roundtrip-{i:02d}"' for i in range(count))
+
+main_tf = f"""
+locals {{
+  spam_filters = {{ {keys} }}
+}}
+
+resource "dash0_spam_filter" "test" {{
+  for_each = local.spam_filters
+
+  dataset = var.dataset
+  spam_filter_yaml = <<-YAML
+    apiVersion: v1alpha1
+    kind: Dash0SpamFilter
+    metadata:
+      name: "Concurrent roundtrip filter ${{each.key}}"
+      annotations:
+        dash0.com/enabled: "true"
+    spec:
+      contexts:
+        - log
+      filter:
+        - key: "k8s.namespace.name"
+          operator: "is"
+          value: "${{each.value}}"
+  YAML
+}}
+
+variable "dataset" {{
+  type = string
+}}
+
+output "origins" {{
+  value = {{ for k, r in dash0_spam_filter.test : k => r.origin }}
+}}
+"""
+
+with open(f"{work_dir}/main.tf", "w") as f:
+    f.write(main_tf)
+PYEOF
+
+tf_init "$WORK_DIR"
+
+# The critical assertion for this bug: before the fix, this single apply
+# would fail for all but one of the FILTER_COUNT resources with an unretried
+# 409 dataset version conflict, and the user had to re-run apply once per
+# losing resource. Now it must converge in exactly one run.
+TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR" \
+  || fail "A single tofu apply did not converge ${FILTER_COUNT} concurrent spam filter creates in dataset ${DATASET} — likely the unretried 409 dataset version conflict from issue #165."
+
+info "All ${FILTER_COUNT} spam filters created in a single apply."
+
+ORIGINS_JSON="$(TF_VAR_dataset="$DATASET" tf_output_json "$WORK_DIR" origins)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Verify all filters exist via dash0 CLI
+# ---------------------------------------------------------------------------
+info "Step 2: Verifying all ${FILTER_COUNT} spam filters exist via dash0 CLI..."
+
+echo "$ORIGINS_JSON" | python3 -c '
+import json, sys
+origins = json.load(sys.stdin)
+for key, origin in sorted(origins.items()):
+    print(f"{key}\t{origin}")
+' > "${WORK_DIR}/origins.tsv"
+
+while IFS=$'\t' read -r key origin; do
+  CLI_OUTPUT="$(dash0 -X spam-filters get "$origin" --dataset "$DATASET" -o yaml 2>&1)" \
+    || fail "dash0 CLI could not find spam filter ${key} (origin ${origin})"
+  echo "$CLI_OUTPUT" | grep -q "concurrent-roundtrip-" \
+    || fail "CLI output for ${key} (origin ${origin}) does not contain expected spam filter content"
+done < "${WORK_DIR}/origins.tsv"
+
+info "All ${FILTER_COUNT} spam filters verified via CLI."
+
+# ---------------------------------------------------------------------------
+# Step 3: Update all filters and re-apply in a single tofu apply
+# ---------------------------------------------------------------------------
+info "Step 3: Updating all ${FILTER_COUNT} spam filters and re-applying in a single tofu apply..."
+
+python3 - "$WORK_DIR" "$FILTER_COUNT" <<'PYEOF'
+import sys
+
+work_dir, count = sys.argv[1], int(sys.argv[2])
+
+keys = ", ".join(f'"filter-{i:02d}" = "concurrent-roundtrip-{i:02d}-updated"' for i in range(count))
+
+main_tf = f"""
+locals {{
+  spam_filters = {{ {keys} }}
+}}
+
+resource "dash0_spam_filter" "test" {{
+  for_each = local.spam_filters
+
+  dataset = var.dataset
+  spam_filter_yaml = <<-YAML
+    apiVersion: v1alpha1
+    kind: Dash0SpamFilter
+    metadata:
+      name: "Concurrent roundtrip filter ${{each.key}} (updated)"
+      annotations:
+        dash0.com/enabled: "true"
+    spec:
+      contexts:
+        - log
+      filter:
+        - key: "k8s.namespace.name"
+          operator: "is"
+          value: "${{each.value}}"
+  YAML
+}}
+
+variable "dataset" {{
+  type = string
+}}
+
+output "origins" {{
+  value = {{ for k, r in dash0_spam_filter.test : k => r.origin }}
+}}
+"""
+
+with open(f"{work_dir}/main.tf", "w") as f:
+    f.write(main_tf)
+PYEOF
+
+TF_VAR_dataset="$DATASET" tf_apply "$WORK_DIR" \
+  || fail "A single tofu apply did not converge ${FILTER_COUNT} concurrent spam filter updates in dataset ${DATASET}."
+
+info "All ${FILTER_COUNT} spam filters updated in a single apply."
+
+while IFS=$'\t' read -r key origin; do
+  CLI_OUTPUT="$(dash0 -X spam-filters get "$origin" --dataset "$DATASET" -o yaml 2>&1)"
+  echo "$CLI_OUTPUT" | grep -q "concurrent-roundtrip-.*-updated" \
+    || fail "CLI output for ${key} (origin ${origin}) does not reflect the update"
+done < "${WORK_DIR}/origins.tsv"
+
+info "Update verified via CLI for all ${FILTER_COUNT} spam filters."
+
+# ---------------------------------------------------------------------------
+# Step 4: Idempotency — re-apply without changes
+# ---------------------------------------------------------------------------
+info "Step 4: Re-applying without changes (idempotency test)..."
+assert_idempotent "$WORK_DIR"
+
+# ---------------------------------------------------------------------------
+# Step 5: Destroy all filters via a single tofu destroy
+# ---------------------------------------------------------------------------
+info "Step 5: Destroying all ${FILTER_COUNT} spam filters via a single tofu destroy..."
+TF_VAR_dataset="$DATASET" tf_destroy "$WORK_DIR" \
+  || fail "A single tofu destroy did not converge ${FILTER_COUNT} concurrent spam filter deletes in dataset ${DATASET}."
+info "All ${FILTER_COUNT} spam filters destroyed in a single destroy."
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify all filters are gone
+# ---------------------------------------------------------------------------
+info "Step 6: Verifying all ${FILTER_COUNT} spam filters are gone..."
+while IFS=$'\t' read -r key origin; do
+  assert_deleted_via_cli "dash0 -X spam-filters get" "$origin" "$DATASET"
+done < "${WORK_DIR}/origins.tsv"
+
+info "=== dash0_spam_filter concurrent writes roundtrip test PASSED ==="


### PR DESCRIPTION
Fixes #165: a single `terraform apply` that creates/updates/deletes more than one `dash0_spam_filter` in the same dataset used to fail with an unretried "409 dataset version conflict" for all but one resource, because Terraform's default parallelism issues those calls concurrently and nothing in the stack retries a 409 (the api-client-go transport only retries 429/5xx, and `upsertSpamFilter` had no retry loop of its own).

Rather than retrying after the fact, this serializes spam filter `Create`/`Update`/`Delete` calls per dataset on the `dash0Client` instance (`lockSpamFilterDataset` in `internal/provider/client/spam_filter.go`), so the race never reaches the API. The lock is keyed by dataset only, so writes to unrelated datasets are unaffected.