### PR TITLE
fix(spam_filter): treat 404 on Read as the resource being gone

### DIFF
--- a/.chloggen/repro-spam-filter-404-on-read.yaml
+++ b/.chloggen/repro-spam-filter-404-on-read.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, check_rules, views)
+component: spam_filters
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Treat a 404 from `Read` as the spam filter no longer existing, removing it from state instead of failing `plan`/`apply`."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [164]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/internal/provider/spam_filter_resource.go
+++ b/internal/provider/spam_filter_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/terraform-provider-dash0/internal/converter"
 	"github.com/dash0hq/terraform-provider-dash0/internal/provider/client"
 	customplanmodifier "github.com/dash0hq/terraform-provider-dash0/internal/provider/planmodifier"
@@ -185,6 +186,11 @@ func (r *SpamFilterResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	apiResponseJSON, err := r.client.GetSpamFilter(ctx, state.Origin.ValueString(), state.Dataset.ValueString())
 	if err != nil {
+		if dash0.IsNotFound(err) {
+			tflog.Debug(ctx, fmt.Sprintf("Spam filter %s no longer exists on the server; removing from state", state.Origin.ValueString()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read spam filter, got error: %s", err))
 		return
 	}

--- a/internal/provider/spam_filter_resource_test.go
+++ b/internal/provider/spam_filter_resource_test.go
@@ -4,12 +4,86 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	dash0 "github.com/dash0hq/dash0-api-client-go"
 	customplanmodifier "github.com/dash0hq/terraform-provider-dash0/internal/provider/planmodifier"
 )
+
+// TestSpamFilterResource_Read_404IsNotHandledAsGone covers the bug reported in
+// https://github.com/dash0hq/terraform-provider-dash0/issues/164 (spam filter
+// deleted out-of-band via the UI, then a Terraform plan/apply runs Read).
+//
+// SpamFilterResource.Read now checks dash0.IsNotFound(err) and calls
+// resp.State.RemoveResource(ctx), so Terraform treats the resource as gone and
+// proposes to re-create it on the next apply, instead of surfacing a hard
+// error that blocks `terraform plan`/`apply` until the user manually runs
+// `terraform state rm`.
+func TestSpamFilterResource_Read_404IsNotHandledAsGone(t *testing.T) {
+	mockClient := &MockClient{}
+	r := &SpamFilterResource{client: mockClient}
+
+	notFound := &dash0.APIError{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		Message:    "spam filter not found",
+		TraceID:    "repro-trace-id",
+	}
+	mockClient.On("GetSpamFilter", mock.Anything, "tf_origin", "dataset-1").
+		Return("", notFound)
+
+	state := tfsdk.State{
+		Raw: tftypes.NewValue(
+			tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"origin":           tftypes.String,
+					"id":               tftypes.String,
+					"dataset":          tftypes.String,
+					"spam_filter_yaml": tftypes.String,
+				},
+			},
+			map[string]tftypes.Value{
+				"origin":           tftypes.NewValue(tftypes.String, "tf_origin"),
+				"id":               tftypes.NewValue(tftypes.String, nil),
+				"dataset":          tftypes.NewValue(tftypes.String, "dataset-1"),
+				"spam_filter_yaml": tftypes.NewValue(tftypes.String, "test-yaml"),
+			},
+		),
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"origin":           schema.StringAttribute{Computed: true},
+				"id":               schema.StringAttribute{Computed: true},
+				"dataset":          schema.StringAttribute{Required: true},
+				"spam_filter_yaml": schema.StringAttribute{Required: true},
+			},
+		},
+	}
+
+	// The real terraform-plugin-framework runtime always seeds
+	// ReadResponse.State from the request state (schema included) before
+	// calling Resource.Read — see internal/fwserver/server_readresource.go.
+	// Mirror that here so RemoveResource(ctx), which needs the schema to
+	// build the null value, has one to work with.
+	req := resource.ReadRequest{State: state}
+	resp := &resource.ReadResponse{State: state}
+
+	r.Read(context.Background(), req, resp)
+
+	// What SHOULD happen, matching team_resource.go's dash0.IsNotFound branch:
+	assert.False(t, resp.Diagnostics.HasError(),
+		"a 404 from GetSpamFilter should be treated as 'resource is gone', not surfaced as a hard error")
+	assert.True(t, resp.State.Raw.IsNull(),
+		"state should be removed via RemoveResource so terraform plan can recreate the spam filter")
+
+	mockClient.AssertExpectations(t)
+}
 
 // TestSpamFilterResource_SharingAnnotationIgnored verifies that spam filters
 // do NOT preserve dash0.com/sharing — changes to it should not trigger a replan.


### PR DESCRIPTION
SpamFilterResource.Read forwarded any GetSpamFilter error straight into a generic "Client Error" diagnostic, so a spam filter deleted out-of-band (e.g. via the web app) blocked every subsequent terraform plan/apply until the user ran `terraform state rm` manually.

Read now checks dash0.IsNotFound(err) and calls resp.State.RemoveResource, so Terraform treats the resource as gone and proposes to recreate it.

Fixes #164